### PR TITLE
feat: adicionar tela de login e sessão do usuário

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.DS_Store

--- a/index.html
+++ b/index.html
@@ -1,198 +1,780 @@
 <!DOCTYPE html>
-<html lang="pt-br">
+<html lang="pt-BR">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>AçaíStock</title>
-    <link rel="stylesheet" href="estilos.css">
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>AçaíStock - Versão Completa</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: '#6D28D9',
+                        secondary: '#9333ea',
+                        danger: '#EF4444',
+                        "background-light": "#FDF7F4",
+                        "background-dark": "#1F2937",
+                        "surface-light": "#FFFFFF",
+                        "surface-dark": "#374151",
+                        "text-light": "#111827",
+                        "text-dark": "#F9FAFB",
+                        "subtle-light": "#6B7280",
+                        "subtle-dark": "#D1D5DB"
+                    },
+                    fontFamily: {
+                        display: ["Poppins", "sans-serif"],
+                    },
+                    borderRadius: {
+                        'DEFAULT': '0.75rem',
+                        'lg': '1rem',
+                        'xl': '1.25rem',
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .card-actions { opacity: 0; transition: opacity 0.3s ease-in-out; pointer-events: none; }
+        .group:hover .card-actions { opacity: 1; pointer-events: auto; }
+        .modal-overlay { transition: opacity 0.3s ease; }
+        .modal-content { transition: transform 0.3s ease; }
+        .loader { border-top-color: #6D28D9; animation: spin 1s linear infinite; }
+        @keyframes spin { to { transform: rotate(360deg); } }
+    </style>
 </head>
-<body>
-    <!-- Container de Login -->
-    <div id="login-container" class="container">
-        <div class="imagem">
-            <img src="img/idle/1.png" alt="monster" id="monster">
-        </div>
-        <div class="formulario">
-            <form id="login-form">
-    <h1>Login</h1>
-    <label for="input-usuario">Nome de Usuário (Login)</label>
-    <div class="input-container">
-        <input type="text" id="input-usuario" placeholder="Digite seu usuário">
-    </div>
-    <label for="input-clave">Senha de Acesso</label>
-    <div class="input-container">
-        <input type="password" id="input-clave" placeholder="Digite sua senha">
-        <span id="toggle-password-login">👁️</span>
-    </div>
-    <button type="submit">Entrar</button>
-    <button type="button" id="show-register">Cadastrar</button>
-</form>
-<form id="register-form" style="display: none;">
-    <h1>Cadastro</h1>
-    <label for="register-username">Nome de Usuário (Login)</label>
-    <div class="input-container">
-        <input type="text" id="register-username" placeholder="Digite seu usuário">
-    </div>
-    <label for="register-password">Senha de Acesso</label>
-    <div class="input-container">
-        <input type="password" id="register-password" placeholder="Digite sua senha">
-        <span id="toggle-password-register">👁️</span>
-    </div>
-    <button type="submit">Cadastrar</button>
-    <button type="button" id="show-login">Voltar ao Login</button>
-</form>
-        </div>
-    </div>
+<body class="bg-background-light dark:bg-background-dark font-display text-text-light dark:text-text-dark antialiased">
+    <div class="flex h-screen">
+        <aside class="w-64 bg-primary text-white flex-col hidden sm:flex">
+            <div class="px-6 py-8 flex items-center"><h1 class="text-2xl font-bold">AçaiStock</h1></div>
+            <nav id="main-menu" class="flex-1 px-4 space-y-2">
+                <a id="home-menu-item" data-page="home-page" class="flex items-center gap-4 px-4 py-3 rounded-lg" href="#"><span class="material-icons">dashboard</span><span class="font-medium">Início</span></a>
+                <a id="stock-menu-item" data-page="stock-page" class="flex items-center gap-4 px-4 py-3 rounded-lg" href="#"><span class="material-icons">inventory_2</span><span class="font-medium">Estoque</span></a>
+                <a id="add-product-link" class="flex items-center gap-4 pl-12 pr-4 py-3 rounded-lg cursor-pointer" href="#"><span class="material-icons">add_circle_outline</span><span class="font-medium">Adicionar</span></a>
+                <a id="moves-menu-item" data-page="moves-page" class="flex items-center gap-4 px-4 py-3 rounded-lg" href="#"><span class="material-icons">swap_horiz</span><span class="font-medium">Movimentações</span></a>
+                <a id="reports-menu-item" data-page="reports-page" class="flex items-center gap-4 px-4 py-3 rounded-lg" href="#"><span class="material-icons">assessment</span><span class="font-medium">Relatórios</span></a>
+            </nav>
+        </aside>
 
-    <!-- Container de Estoque -->
-    <div id="stock-container" style="display: none;">
-        <div class="sidebar">
-            <h2>Menu</h2>
-            <ul>
-                <li class="menu-item">
-            <span id="home-menu">Início</span>
-        </li>
-        <li class="menu-item">
-            <span id="estoque-menu">Estoque</span>
-            <ul class="submenu">
-                <li><a href="#" id="show-add-product">Adicionar Produto</a></li>
-            </ul>
-        </li>
-        <li class="menu-item">
-            <span id="movimentacoes-menu">Movimentações</span>
-        </li>
-                <li class="menu-item">
-            <span id="relatorios-menu">Relatórios</span>
-        </li>
-    </ul>
-</div>
-<div class="main-content">
-            <header>
-                <h1>AçaíStock</h1>
-                <div class="user-profile">
-                    <img src="https://i.ibb.co/bg3wvFK0/585e4beacb11b227491c3399.png" alt="Foto do Usuário" class="user-profile-pic" id="user-profile-pic">
-                    <span id="user-name">Usuário</span>
-                    <div class="user-menu" style="display: none;">
-                        <button id="approve-users-btn" style="display:none;">Aprovar Cadastros</button>
-                        <button id="delete-users-btn" style="display:none;">Excluir Usuários</button>
-                        <button id="logout-btn">Sair</button>
+        <div id="main-content" class="flex-1 flex flex-col overflow-hidden">
+            <div id="home-page" class="page-content flex-1 flex flex-col">
+                 <header class="flex items-center justify-between p-6 bg-surface-light dark:bg-surface-dark border-b border-gray-200 dark:border-gray-700">
+                    <div><h2 class="text-2xl font-bold">Dashboard</h2><p class="text-subtle-light dark:text-subtle-dark">Bem-vindo de volta, <span id="user-welcome-name">IThallo</span>!</p></div>
+                    <div class="relative">
+                        <button class="user-menu-button flex items-center gap-3 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                            <img src="https://placehold.co/40x40/6D28D9/FFFFFF?text=I" alt="Avatar do Usuário" class="user-avatar-img w-10 h-10 rounded-full object-cover">
+                            <span class="font-medium hidden md:block user-name-text">IThallo</span>
+                            <span class="material-icons text-subtle-light dark:text-subtle-dark">expand_more</span>
+                        </button>
+                        <div class="user-dropdown-menu hidden absolute right-0 mt-2 w-48 bg-surface-light dark:bg-surface-dark rounded-lg shadow-xl z-10 border border-gray-200 dark:border-gray-600">
+                            <a href="#" class="profile-link block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Perfil</a>
+                            <a href="#" data-page="approve-page" class="approve-link block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Aprovar Cadastro</a>
+                            <div class="border-t border-gray-200 dark:border-gray-600"></div>
+                            <a href="#" class="logout-link block px-4 py-2 text-sm text-danger dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">Sair</a>
+                        </div>
+                    </div>
+                </header>
+                <div class="flex-1 p-8 overflow-y-auto">
+                    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+                        <div class="bg-surface-light dark:bg-surface-dark p-6 rounded-xl shadow-sm flex items-start justify-between"><div><p class="text-sm font-medium text-subtle-light dark:text-subtle-dark">Itens em Estoque</p><p id="home-kpi-total-stock" class="text-3xl font-bold mt-1"></p></div><div class="bg-primary/10 text-primary p-3 rounded-lg"><span class="material-icons">inventory_2</span></div></div>
+                        <div class="bg-surface-light dark:bg-surface-dark p-6 rounded-xl shadow-sm flex items-start justify-between"><div><p class="text-sm font-medium text-subtle-light dark:text-subtle-dark">Estoque Baixo</p><p id="home-kpi-low-stock" class="text-3xl font-bold mt-1"></p></div><div class="bg-yellow-500/10 text-yellow-500 p-3 rounded-lg"><span class="material-icons">warning</span></div></div>
+                        <div class="bg-surface-light dark:bg-surface-dark p-6 rounded-xl shadow-sm flex items-start justify-between"><div><p class="text-sm font-medium text-subtle-light dark:text-subtle-dark">Movimentações (Hoje)</p><p id="home-kpi-moves" class="text-3xl font-bold mt-1"></p></div><div class="bg-blue-500/10 text-blue-500 p-3 rounded-lg"><span class="material-icons">swap_horiz</span></div></div>
+                        <div class="bg-surface-light dark:bg-surface-dark p-6 rounded-xl shadow-sm flex items-start justify-between"><div><p class="text-sm font-medium text-subtle-light dark:text-subtle-dark">Valor do Estoque</p><p id="home-kpi-stock-value" class="text-3xl font-bold mt-1"></p></div><div class="bg-green-500/10 text-green-500 p-3 rounded-lg"><span class="material-icons">attach_money</span></div></div>
+                    </div>
+                    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                        <div id="recent-activity" class="lg:col-span-2 bg-surface-light dark:bg-surface-dark p-6 rounded-xl shadow-sm"><h3 class="text-lg font-semibold mb-4">Atividade Recente</h3><div id="recent-activity-list" class="space-y-4"></div></div>
+                        <div class="bg-surface-light dark:bg-surface-dark p-6 rounded-xl shadow-sm"><h3 class="text-lg font-semibold mb-4">Ações Rápidas</h3><div class="space-y-3"><button id="quick-add-product" class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-primary text-white font-semibold rounded-lg hover:bg-primary/90 transition-colors shadow-sm"><span class="material-icons">add_circle_outline</span>Novo Produto</button><button id="quick-export-report" class="w-full flex items-center justify-center gap-2 px-4 py-3 bg-gray-200 dark:bg-gray-600 font-semibold rounded-lg hover:bg-gray-300 dark:hover:bg-gray-500 transition-colors"><span class="material-icons">file_download</span>Exportar Relatório</button></div></div>
                     </div>
                 </div>
-            </header>
-            
-            <!-- Seção Home -->
-            <div id="home-section" class="home-section">
-                <div class="welcome-card">
-                    <h2>Bem-vindo ao Sistema do AçaíStock!</h2>
-                    <p>Gerencie seus produtos de forma eficiente e organizada. Use o menu lateral para navegar pelas funcionalidades do sistema.</p>
+            </div>
+
+            <div id="stock-page" class="page-content flex-1 flex flex-col hidden">
+                <header class="flex justify-between items-center p-6 bg-surface-light dark:bg-surface-dark border-b dark:border-gray-700">
+                    <h1 class="text-2xl font-bold">Estoque</h1>
+                    <div class="relative">
+                        <button class="user-menu-button flex items-center gap-3 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                           <img src="https://placehold.co/40x40/6D28D9/FFFFFF?text=I" alt="Avatar do Usuário" class="user-avatar-img w-10 h-10 rounded-full object-cover">
+                            <span class="font-medium hidden md:block user-name-text">IThallo</span>
+                            <span class="material-icons text-subtle-light dark:text-subtle-dark">expand_more</span>
+                        </button>
+                        <div class="user-dropdown-menu hidden absolute right-0 mt-2 w-48 bg-surface-light dark:bg-surface-dark rounded-lg shadow-xl z-10 border border-gray-200 dark:border-gray-600">
+                            <a href="#" class="profile-link block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Perfil</a>
+                            <a href="#" data-page="approve-page" class="approve-link block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Aprovar Cadastro</a>
+                            <div class="border-t border-gray-200 dark:border-gray-600"></div>
+                            <a href="#" class="logout-link block px-4 py-2 text-sm text-danger dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">Sair</a>
+                        </div>
+                    </div>
+                </header>
+                <div class="p-6 bg-surface-light dark:bg-surface-dark"><div class="flex flex-col md:flex-row md:items-center md:justify-between space-y-4 md:space-y-0 gap-4"><div class="relative flex-1 md:max-w-md"><span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">search</span><input id="search-input" class="w-full pl-10 pr-4 py-2 border rounded-lg focus:ring-primary focus:border-primary bg-background-light dark:bg-background-dark" placeholder="Buscar..." type="text" /></div><div class="flex items-center space-x-2 flex-wrap gap-2"><div id="filter-buttons" class="flex items-center space-x-2"><button data-filter="all" class="filter-btn px-4 py-2 rounded-lg text-sm font-medium">Todos</button><button data-filter="low_stock" class="filter-btn px-4 py-2 rounded-lg text-sm font-medium">Estoque Baixo</button><button data-filter="expiring_soon" class="filter-btn px-4 py-2 rounded-lg text-sm font-medium">Vencendo</button></div><button id="suggest-product-btn" class="px-4 py-2 bg-secondary text-white rounded-lg text-sm font-medium flex items-center space-x-2"><span class="material-icons text-base">auto_awesome</span><span>Sugerir</span></button><div class="flex items-center border border-gray-300 dark:border-gray-700 rounded-lg"><button id="grid-view-btn" class="p-2"><span class="material-icons">grid_view</span></button><button id="list-view-btn" class="p-2"><span class="material-icons">view_list</span></button></div></div></div></div>
+                <div id="product-container" class="flex-1 p-6 overflow-y-auto bg-background-light dark:bg-background-dark flex flex-col"><div id="product-grid" class="flex-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6"></div><div id="pagination-controls" class="flex justify-center items-center mt-8 space-x-2"></div></div>
+            </div>
+
+            <div id="reports-page" class="page-content hidden flex-1 flex flex-col">
+                <header class="flex justify-between items-center p-6 bg-surface-light dark:bg-surface-dark border-b dark:border-gray-700">
+                    <h1 class="text-2xl font-bold">Relatórios</h1>
+                    <div class="flex items-center gap-4">
+                        <button id="ai-analysis-btn" class="px-4 py-2 bg-secondary text-white rounded-lg text-sm font-medium flex items-center space-x-2">
+                            <span class="material-icons text-base">auto_awesome</span>
+                            <span>Analisar com IA</span>
+                        </button>
+                        <div class="relative">
+                            <button class="user-menu-button flex items-center gap-3 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                                <img src="https://placehold.co/40x40/6D28D9/FFFFFF?text=I" alt="Avatar do Usuário" class="user-avatar-img w-10 h-10 rounded-full object-cover">
+                                <span class="font-medium hidden md:block user-name-text">IThallo</span>
+                                <span class="material-icons text-subtle-light dark:text-subtle-dark">expand_more</span>
+                            </button>
+                            <div class="user-dropdown-menu hidden absolute right-0 mt-2 w-48 bg-surface-light dark:bg-surface-dark rounded-lg shadow-xl z-10 border border-gray-200 dark:border-gray-600">
+                                <a href="#" class="profile-link block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Perfil</a>
+                                <a href="#" data-page="approve-page" class="approve-link block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Aprovar Cadastro</a>
+                                <div class="border-t border-gray-200 dark:border-gray-600"></div>
+                                <a href="#" class="logout-link block px-4 py-2 text-sm text-danger dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">Sair</a>
+                            </div>
+                        </div>
+                    </div>
+                </header>
+                <div class="flex-1 p-8 overflow-y-auto bg-background-light dark:bg-background-dark">
+                    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
+                        <div class="bg-surface-light dark:bg-surface-dark p-5 rounded-xl shadow-sm flex items-center"><div class="p-3 rounded-full bg-green-500/10"><span class="material-icons text-2xl text-green-500">arrow_downward</span></div><div class="ml-4"><p class="text-sm text-subtle-light dark:text-subtle-dark">Total de Entradas</p><p id="kpi-inputs" class="text-2xl font-bold"></p></div></div>
+                        <div class="bg-surface-light dark:bg-surface-dark p-5 rounded-xl shadow-sm flex items-center"><div class="p-3 rounded-full bg-red-500/10"><span class="material-icons text-2xl text-danger">arrow_upward</span></div><div class="ml-4"><p class="text-sm text-subtle-light dark:text-subtle-dark">Total de Saídas</p><p id="kpi-outputs" class="text-2xl font-bold"></p></div></div>
+                        <div class="bg-surface-light dark:bg-surface-dark p-5 rounded-xl shadow-sm flex items-center"><div class="p-3 rounded-full bg-primary/10"><span class="material-icons text-2xl text-primary">inventory</span></div><div class="ml-4"><p class="text-sm text-subtle-light dark:text-subtle-dark">Estoque Atual</p><p id="kpi-total-stock" class="text-2xl font-bold"></p></div></div>
+                        <div class="bg-surface-light dark:bg-surface-dark p-5 rounded-xl shadow-sm flex items-center"><div class="p-3 rounded-full bg-yellow-500/10"><span class="material-icons text-2xl text-yellow-500">warning</span></div><div class="ml-4"><p class="text-sm text-subtle-light dark:text-subtle-dark">Alertas (Venc.)</p><p id="kpi-expiring" class="text-2xl font-bold"></p></div></div>
+                    </div>
+                    <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+                        <div class="bg-surface-light dark:bg-surface-dark p-6 rounded-xl shadow-sm h-96"><h3 class="font-semibold text-lg mb-4">Estoque por Produto</h3><canvas id="stock-by-product-chart"></canvas></div>
+                        <div class="bg-surface-light dark:bg-surface-dark p-6 rounded-xl shadow-sm h-96"><h3 class="font-semibold text-lg mb-4">Distribuição por Tipo</h3><canvas id="stock-by-type-chart"></canvas></div>
+                    </div>
                 </div>
             </div>
-            
-            <div id="add-product-section" style="display: none;">
-                <h2>Adicionar Novo Produto</h2>
-                <form id="stock-form">
-                    <input type="text" id="produto" placeholder="Produto" required>
-                    <input type="text" id="tipo" placeholder="Tipo">
-                    <input type="text" id="lote" placeholder="Lote">
-                    <input type="date" id="validade" placeholder="Validade">
-                    <input type="number" id="quantidade" placeholder="Quantidade" required>
-                    <button type="submit">Adicionar Produto</button>
-                </form>
-            </div>
-            <div id="view-stock-section" style="display: none;">
-                <h2>Estoque</h2>
-                <div class="filter-container">
-                    <input type="text" id="filter-input" placeholder="Filtrar por nome ou tipo">
-                    <select id="filter-type">
-                        <option value="all">Todos</option>
-                        <option value="produto">Nome</option>
-                        <option value="tipo">Tipo</option>
-                    </select>
+
+            <div id="approve-page" class="page-content hidden flex-1 flex flex-col">
+                <header class="flex justify-between items-center p-6 bg-surface-light dark:bg-surface-dark border-b dark:border-gray-700">
+                    <h1 class="text-2xl font-bold">Gerenciar Cadastros</h1>
+                    <div class="relative">
+                        <button class="user-menu-button flex items-center gap-3 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                            <img src="https://placehold.co/40x40/6D28D9/FFFFFF?text=I" alt="Avatar do Usuário" class="user-avatar-img w-10 h-10 rounded-full object-cover">
+                            <span class="font-medium hidden md:block user-name-text">IThallo</span>
+                            <span class="material-icons text-subtle-light dark:text-subtle-dark">expand_more</span>
+                        </button>
+                        <div class="user-dropdown-menu hidden absolute right-0 mt-2 w-48 bg-surface-light dark:bg-surface-dark rounded-lg shadow-xl z-10 border border-gray-200 dark:border-gray-600">
+                            <a href="#" class="profile-link block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Perfil</a>
+                            <a href="#" data-page="approve-page" class="approve-link block px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600">Aprovar Cadastro</a>
+                            <div class="border-t border-gray-200 dark:border-gray-600"></div>
+                            <a href="#" class="logout-link block px-4 py-2 text-sm text-danger dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20">Sair</a>
+                        </div>
+                    </div>
+                </header>
+                <div class="flex-1 p-8 overflow-y-auto bg-background-light dark:bg-background-dark space-y-8">
+                    <div>
+                        <h2 class="text-lg font-semibold mb-4">Aguardando Aprovação</h2>
+                        <div id="pending-users-list" class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm p-4 space-y-3"></div>
+                    </div>
+                    <div>
+                        <h2 class="text-lg font-semibold mb-4">Usuários Ativos</h2>
+                        <div id="active-users-list" class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm p-4 space-y-3"></div>
+                    </div>
                 </div>
-                <table id="stock-table">
-                    <thead>
-                        <tr>
-                            <th>Produto</th>
-                            <th>Tipo</th>
-                            <th>Lote</th>
-                            <th>Validade</th>
-                            <th>Quantidade</th>
-                            <th>Ações</th>
-                        </tr>
-                    </thead>
-                    <tbody id="stock-table-body"></tbody>
-                </table>
-                <div id="pagination"></div>
             </div>
-            <div id="movimentacoes-section" style="display: none;">
-    <h2>Movimentações</h2>
-                <div class="filtro-movimentacoes">
-        <input type="date" id="mov-inicio">
-        <input type="date" id="mov-fim">
-        <button id="filtrar-mov-btn">Filtrar</button>
-    </div>
-    <table id="movimentacoes-table">
-        <thead>
-            <tr>
-                <th>Data</th>
-                <th>Usuário</th>
-                <th>Produto</th>
-                <th>Tipo</th>
-            <th>Qtd. Antes</th>
-            <th>Quantidade</th>
-            <th>Total Atual</th>
-            <th>Motivo</th>
-        </tr>
-    </thead>
-    <tbody id="movimentacoes-table-body"></tbody>
-</table>
-    </div>
 
-    <div id="relatorios-section" style="display: none;">
-                <h2>Relatórios</h2>
-                <div class="filtro-relatorios">
-                    <input type="date" id="filtro-inicio">
-                    <input type="date" id="filtro-fim">
-    <button id="aplicar-filtro-btn">Aplicar Filtro</button>
-</div>
-<div class="charts-grid">
-    <div class="chart-container">
-        <canvas id="por-produto-chart"></canvas>
-    </div>
-    <div class="chart-container">
-        <canvas id="por-dia-chart"></canvas>
-    </div>
-    <div class="chart-container">
-        <canvas id="pizza-produto-chart"></canvas>
-    </div>
-    <div class="chart-container">
-        <canvas id="pizza-tipo-chart"></canvas>
-    </div>
-<button id="export-csv-btn">Exportar CSV</button>
+            <div id="moves-page" class="page-content hidden flex-1 flex flex-col">
+                <header class="flex justify-between items-center p-6 bg-surface-light dark:bg-surface-dark border-b dark:border-gray-700"><h1 class="text-2xl font-bold">Movimentações</h1></header>
+                <div class="flex-1 p-6 flex items-center justify-center bg-background-light dark:bg-background-dark"><div class="text-center"><span class="material-icons text-6xl text-gray-300 dark:text-gray-600">construction</span><h2 class="mt-4 text-xl font-semibold">Página em Construção</h2><p class="text-subtle-light dark:text-subtle-dark">Esta área será desenvolvida em breve.</p></div></div>
             </div>
-        </div>
-
-    <div id="admin-section" style="display: none;">
-        <h2>Administração de Usuários</h2>
-        <h3>Cadastros Pendentes</h3>
-        <ul id="pending-users-list"></ul>
-        <h3>Usuários Registrados</h3>
-        <ul id="users-list"></ul>
-        <button id="close-admin">Fechar</button>
-    </div>
-    
-    <!-- Modal de Foto de Perfil -->
-    <div id="profile-modal" class="profile-modal" style="display: none;">
-        <div class="profile-modal-content">
-            <button class="close-btn" id="close-profile-modal">&times;</button>
-            <img src="https://i.ibb.co/bg3wvFK0/585e4beacb11b227491c3399.png" alt="Foto do Usuário" class="profile-modal-pic" id="profile-modal-pic">
-            <br>
-            <button class="change-photo-btn" id="change-photo-btn">Alterar Foto</button>
-            <input type="file" id="photo-upload" class="photo-upload" accept="image/*">
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="javascript.js"></script>
+    <div id="profile-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 hidden"><div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-xl w-full max-w-md"><header class="flex items-center justify-between p-4 border-b dark:border-gray-700"><h2 class="text-xl font-bold flex items-center gap-2"><span class="material-icons">person</span><span>Meu Perfil</span></h2><button data-close-modal="profile-modal" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"><span class="material-icons">close</span></button></header><main class="p-6 space-y-4 flex flex-col items-center"><img id="profile-modal-image" src="" alt="Foto de Perfil" class="w-32 h-32 rounded-full object-cover mb-4 border-4 border-primary"><label for="profile-image-upload" class="cursor-pointer bg-secondary text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-secondary/90">Alterar Foto<input type="file" name="profile_image" id="profile-image-upload" class="hidden" accept="image/*"></label></main><footer class="flex justify-end p-4 bg-gray-50 dark:bg-gray-800 space-x-2"><button type="button" data-close-modal="profile-modal" class="px-4 py-2 rounded-lg">Fechar</button><button id="save-profile-btn" type="button" class="px-4 py-2 bg-primary text-white rounded-lg">Salvar</button></footer></div></div>
+    <div id="ai-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 hidden"><div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col"><header class="flex items-center justify-between p-4 border-b dark:border-gray-700"><h2 id="ai-modal-title" class="text-xl font-bold flex items-center gap-2"><span class="material-icons text-secondary">auto_awesome</span><span></span></h2><button data-close-modal="ai-modal" class="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700"><span class="material-icons">close</span></button></header><main id="ai-modal-body" class="p-6 overflow-y-auto"></main></div></div>
+    <div id="add-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 hidden"><div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-xl w-full max-w-lg"><header class="flex items-center justify-between p-4 border-b dark:border-gray-700"><h2 class="text-xl font-bold flex items-center gap-2"><span class="material-icons">add_circle</span><span>Adicionar</span></h2><button data-close-modal="add-modal" class="p-2 rounded-full"><span class="material-icons">close</span></button></header><form id="add-form"><main class="p-6 space-y-4"><label class="block text-sm font-medium">Imagem<input type="file" name="image" id="add-image" class="w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-violet-50 file:text-primary hover:file:bg-violet-100"><img id="add-image-preview" src="https://placehold.co/100x100/E2E8F0/4A5568?text=Preview" alt="Preview" class="mt-2 rounded-md h-24 w-24 object-cover hidden"></label><label class="block text-sm font-medium">Tipo<select name="type" id="add-type" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"><option>Açaí</option><option>Sorvete</option><option>Complemento</option><option>Bebida</option></select></label><label class="block text-sm font-medium">Nome<input type="text" name="name" id="add-name" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"></label><label class="block text-sm font-medium">Lote<input type="text" name="lot" id="add-lot" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"></label><div class="grid grid-cols-2 gap-4"><label class="block text-sm font-medium">Quantidade<input type="number" name="quantity" id="add-quantity" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"></label><label class="block text-sm font-medium">Validade<input type="date" name="expiryDate" id="add-expiryDate" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"></label></div></main><footer class="flex justify-end p-4 bg-gray-50 dark:bg-gray-800 space-x-2"><button type="button" data-close-modal="add-modal" class="px-4 py-2 rounded-lg">Cancelar</button><button type="submit" class="px-4 py-2 bg-primary text-white rounded-lg">Adicionar</button></footer></form></div></div>
+    <div id="edit-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 hidden"><div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-xl w-full max-w-lg"><header class="flex items-center justify-between p-4 border-b dark:border-gray-700"><h2 class="text-xl font-bold flex items-center gap-2"><span class="material-icons">edit</span><span>Editar</span></h2><button data-close-modal="edit-modal" class="p-2 rounded-full"><span class="material-icons">close</span></button></header><form id="edit-form"><main class="p-6 space-y-4"><input type="hidden" id="edit-id" name="id"><label class="block text-sm font-medium">Imagem<input type="file" name="image" id="edit-image" class="w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-violet-50 file:text-primary hover:file:bg-violet-100"><img id="edit-image-preview" src="" alt="Preview" class="mt-2 rounded-md h-24 w-24 object-cover"></label><label class="block text-sm font-medium">Tipo<select name="type" id="edit-type" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"><option>Açaí</option><option>Sorvete</option><option>Complemento</option><option>Bebida</option></select></label><label class="block text-sm font-medium">Nome<input type="text" name="name" id="edit-name" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"></label><label class="block text-sm font-medium">Lote<input type="text" name="lot" id="edit-lot" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"></label><div class="grid grid-cols-2 gap-4"><label class="block text-sm font-medium">Quantidade<input type="number" name="quantity" id="edit-quantity" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"></label><label class="block text-sm font-medium">Validade<input type="date" name="expiryDate" id="edit-expiryDate" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark"></label></div></main><footer class="flex justify-end p-4 bg-gray-50 dark:bg-gray-800 space-x-2"><button type="button" data-close-modal="edit-modal" class="px-4 py-2 rounded-lg">Cancelar</button><button type="submit" class="px-4 py-2 bg-primary text-white rounded-lg">Salvar</button></footer></form></div></div>
+    <div id="delete-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 hidden"><div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-xl w-full max-w-md"><header class="flex items-center p-4"><span class="material-icons text-danger text-2xl mr-3">warning</span><h2 class="text-xl font-bold">Confirmar Exclusão</h2></header><main class="p-6 pt-0"><p>Excluir "<strong id="delete-product-name"></strong>"?</p></main><footer class="flex justify-end p-4 bg-gray-50 dark:bg-gray-800 space-x-2"><button type="button" data-close-modal="delete-modal" class="px-4 py-2 rounded-lg">Cancelar</button><button id="confirm-delete-btn" type="button" class="px-4 py-2 bg-danger text-white rounded-lg">Excluir</button></footer></div></div>
+    <div id="loader" class="fixed inset-0 bg-black bg-opacity-30 z-[60] flex items-center justify-center hidden"><div class="loader h-16 w-16 rounded-full border-4 border-t-4 border-gray-200"></div></div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', async () => {
+        const rememberedUserString = localStorage.getItem('acai-user');
+        const storedUserString = sessionStorage.getItem('acai-user') || rememberedUserString;
+
+        if (storedUserString && !sessionStorage.getItem('acai-user')) {
+            sessionStorage.setItem('acai-user', storedUserString);
+        }
+
+        const storedUser = storedUserString ? JSON.parse(storedUserString) : null;
+        if (!storedUser) {
+            window.location.replace('login.html');
+            return;
+        }
+
+        const defaultAvatar = 'https://placehold.co/100x100/6D28D9/FFFFFF?text=I';
+        let currentUserData = {
+            id: storedUser.id || null,
+            username: (storedUser.username || 'IThallo').toString().trim() || 'IThallo',
+            role: storedUser.role || 'user',
+            photo: storedUser.photo || null
+        };
+        let userProfile = {
+            name: currentUserData.username,
+            avatar: currentUserData.photo || defaultAvatar
+        };
+
+        const syncStoredUser = () => {
+            sessionStorage.setItem('acai-user', JSON.stringify(currentUserData));
+            if (localStorage.getItem('acai-user')) {
+                localStorage.setItem('acai-user', JSON.stringify(currentUserData));
+            }
+        };
+
+        const updateUserVisuals = () => {
+            const nameToShow = userProfile.name || 'Usuário';
+            document.querySelectorAll('.user-avatar-img').forEach(img => { img.src = userProfile.avatar; });
+            document.querySelectorAll('.user-name-text').forEach(el => { el.textContent = nameToShow; });
+            const welcomeName = document.getElementById('user-welcome-name');
+            if (welcomeName) {
+                const firstName = nameToShow.split(' ')[0] || nameToShow;
+                welcomeName.textContent = firstName;
+            }
+        };
+
+        updateUserVisuals();
+        syncStoredUser();
+
+        if (!currentUserData.photo && currentUserData.id) {
+            try {
+                const response = await fetch(`/api/users/${currentUserData.id}/photo`);
+                if (response.ok) {
+                    const data = await response.json();
+                    if (data?.photo) {
+                        currentUserData.photo = data.photo;
+                        userProfile.avatar = data.photo;
+                        updateUserVisuals();
+                        syncStoredUser();
+                    }
+                }
+            } catch (error) {
+                console.error('Não foi possível carregar a foto do usuário.', error);
+            }
+        }
+
+        let usersData = [
+            { id: 1, name: 'Ana Silva', email: 'ana.silva@email.com', avatar: 'https://placehold.co/40x40/f472b6/ffffff?text=A', status: 'pending' },
+            { id: 2, name: 'Carlos Souza', email: 'carlos.souza@email.com', avatar: 'https://placehold.co/40x40/38bdf8/ffffff?text=C', status: 'pending' },
+            { id: 3, name: 'Bruno Lima', email: 'bruno.lima@email.com', avatar: 'https://placehold.co/40x40/22c55e/ffffff?text=B', status: 'active' },
+            { id: 4, name: 'Daniela Costa', email: 'daniela.costa@email.com', avatar: 'https://placehold.co/40x40/eab308/ffffff?text=D', status: 'active' }
+        ];
+        let productData = [
+             { id: 1, type: 'Açaí', name: 'Açaí com Banana', lot: 'A-112', quantity: 43, expiryDate: '2025-09-09', image: 'https://placehold.co/400x300/C8B6FF/4B0082?text=Açaí+Banana', cost: 15.50 },
+             { id: 2, type: 'Açaí', name: 'Açaí com Morango', lot: 'A-113', quantity: 81, expiryDate: '2025-10-15', image: 'https://placehold.co/400x300/A2E3C4/004D40?text=Açaí+Morango', cost: 16.00 },
+             { id: 3, type: 'Açaí', name: 'Açaí Premium Natural', lot: 'A-114', quantity: 22, expiryDate: '2025-10-30', image: 'https://placehold.co/400x300/9FA8DA/1A237E?text=Açaí+Natural', cost: 14.00 },
+             { id: 4, type: 'Sorvete', name: 'Sorvete de Ninho', lot: 'S-305', quantity: 150, expiryDate: '2026-08-14', image: 'https://placehold.co/400x300/BCAAA4/3E2723?text=Sorvete+Ninho', cost: 12.00 },
+             { id: 5, type: 'Bebida', name: 'Suco de Laranja', lot: 'L-450', quantity: 60, expiryDate: '2025-09-28', image: 'https://placehold.co/400x300/FFAB91/BF360C?text=Suco+Laranja', cost: 5.00 },
+        ];
+        let movementsData = [
+            { type: 'input', quantity: 500, date: new Date() }, { type: 'input', quantity: 300, date: new Date() },
+            { type: 'output', quantity: 200, date: new Date() }, { type: 'output', quantity: 180, date: new Date() }
+        ];
+        let activityLog = [
+            { icon: 'add', color: 'green', title: 'Entrada: 50x Polpa de Açaí', subtitle: `Usuário: ${userProfile.name}`, time: 'há 15 minutos' },
+            { icon: 'remove', color: 'red', title: 'Saída: 10x Granola 500g', subtitle: 'Pedido #1204', time: 'há 1 hora' },
+            { icon: 'edit', color: 'yellow', title: 'Produto "Leite em Pó" atualizado', subtitle: 'Estoque mínimo alterado', time: 'há 3 horas' },
+        ];
+        let currentProductId = null;
+        let stockByProductChart, stockByTypeChart;
+        let currentView = 'grid';
+        let currentlyDisplayedProducts = [];
+        let currentPage = 1;
+        const itemsPerPage = 8;
+
+        const handleLogout = () => {
+            sessionStorage.removeItem('acai-user');
+            localStorage.removeItem('acai-user');
+            window.location.href = 'login.html';
+        };
+        const mainMenu = document.getElementById('main-menu');
+        const mainContent = document.getElementById('main-content');
+        const addProductLink = document.getElementById('add-product-link');
+        const addForm = document.getElementById('add-form');
+        const editForm = document.getElementById('edit-form');
+        const productGrid = document.getElementById('product-grid');
+        const searchInput = document.getElementById('search-input');
+        const filterButtonsContainer = document.getElementById('filter-buttons');
+        const confirmDeleteBtn = document.getElementById('confirm-delete-btn');
+        const suggestProductBtn = document.getElementById('suggest-product-btn');
+        const aiAnalysisBtn = document.getElementById('ai-analysis-btn');
+        const quickAddBtn = document.getElementById('quick-add-product');
+        const quickExportBtn = document.getElementById('quick-export-report');
+        const saveProfileBtn = document.getElementById('save-profile-btn');
+        const gridViewBtn = document.getElementById('grid-view-btn');
+        const listViewBtn = document.getElementById('list-view-btn');
+
+        const switchPage = (pageId) => {
+            document.querySelectorAll('.page-content').forEach(page => page.classList.add('hidden'));
+            document.getElementById(pageId)?.classList.remove('hidden');
+            if(pageId === 'reports-page') updateReports();
+            if(pageId === 'home-page') updateHomePage();
+            if(pageId === 'approve-page') renderApprovalPage();
+        };
+        const openModal = (modalId) => document.getElementById(modalId)?.classList.remove('hidden');
+        const closeModal = (modalId) => document.getElementById(modalId)?.classList.add('hidden');
+        const showLoader = () => document.getElementById('loader').classList.remove('hidden');
+        const hideLoader = () => document.getElementById('loader').classList.add('hidden');
+        const setupImagePreview = (inputId, previewId) => {
+            const input = document.getElementById(inputId), preview = document.getElementById(previewId);
+            input.addEventListener('change', () => {
+                if (input.files[0]) {
+                    const reader = new FileReader();
+                    reader.onload = e => { preview.src = e.target.result; preview.classList.remove('hidden'); }
+                    reader.readAsDataURL(input.files[0]);
+                }
+            });
+        };
+        const callGeminiAPI = async (prompt) => {
+             showLoader();
+             try {
+                const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=`;
+                const response = await fetch(url, { method: 'POST', headers: {'Content-Type': 'application/json'}, body: JSON.stringify({ contents: [{ parts: [{ text: prompt }] }] }) });
+                if (!response.ok) throw new Error(`HTTP error! status: ${response.status}`);
+                const result = await response.json();
+                const text = result.candidates?.[0]?.content?.parts?.[0]?.text;
+                if (!text) throw new Error("Resposta da IA inválida.");
+                return text.replace(/\n/g, '<br>');
+             } catch (error) {
+                console.error("Gemini API call failed:", error);
+                return "Erro ao contatar a IA. Tente novamente.";
+             } finally {
+                hideLoader();
+             }
+        };
+
+        const openProfileModal = () => { document.getElementById('profile-modal-image').src = userProfile.avatar; openModal('profile-modal'); };
+        const handleProfileSave = () => {
+            const newAvatarSrc = document.getElementById('profile-modal-image').src;
+            userProfile.avatar = newAvatarSrc;
+            currentUserData.photo = newAvatarSrc;
+            updateUserVisuals();
+            syncStoredUser();
+            closeModal('profile-modal');
+        };
+        const openAddModal = () => { addForm.reset(); document.getElementById('add-image-preview').classList.add('hidden'); openModal('add-modal'); }
+        const openEditModal = (id) => {
+            currentProductId = id;
+            const product = productData.find(p => p.id === id);
+            if (product) {
+                const preview = document.getElementById('edit-image-preview');
+                editForm.elements.id.value = product.id;
+                editForm.elements.type.value = product.type;
+                editForm.elements.name.value = product.name;
+                editForm.elements.lot.value = product.lot;
+                editForm.elements.quantity.value = product.quantity;
+                editForm.elements.expiryDate.value = product.expiryDate;
+                preview.src = product.image;
+                preview.classList.remove('hidden');
+                openModal('edit-modal');
+            }
+        };
+        const openDeleteModal = (id) => {
+            currentProductId = id;
+            const product = productData.find(p => p.id === id);
+            if(product) { document.getElementById('delete-product-name').textContent = product.name; openModal('delete-modal'); }
+        };
+        const handleAddSubmit = (e) => {
+            e.preventDefault();
+            const formData = new FormData(addForm);
+            const imageInput = document.getElementById('add-image');
+            const imageSrc = imageInput.files[0] ? document.getElementById('add-image-preview').src : `https://placehold.co/400x300/E2E8F0/4A5568?text=${encodeURIComponent(formData.get('name'))}`;
+            const newId = productData.length > 0 ? Math.max(...productData.map(p => p.id)) + 1 : 1;
+            const newProduct = {
+                id: newId, type: formData.get('type'), name: formData.get('name'), lot: formData.get('lot'),
+                quantity: parseInt(formData.get('quantity')), expiryDate: formData.get('expiryDate'),
+                image: imageSrc, cost: parseFloat(Math.random() * 10 + 5).toFixed(2)
+            };
+            productData.push(newProduct);
+            closeModal('add-modal');
+            applyFiltersAndPaginate();
+        };
+        const handleEditSubmit = (e) => {
+            e.preventDefault();
+            const formData = new FormData(editForm);
+            const productId = parseInt(formData.get('id'));
+            const imageSrc = document.getElementById('edit-image-preview').src;
+            const productIndex = productData.findIndex(p => p.id === productId);
+            if (productIndex > -1) {
+                productData[productIndex] = { ...productData[productIndex],
+                    type: formData.get('type'), name: formData.get('name'), lot: formData.get('lot'),
+                    quantity: parseInt(formData.get('quantity')), expiryDate: formData.get('expiryDate'),
+                    image: imageSrc,
+                };
+            }
+            closeModal('edit-modal');
+            applyFiltersAndPaginate();
+        };
+        const handleDeleteConfirm = () => { productData = productData.filter(p => p.id !== currentProductId); closeModal('delete-modal'); applyFiltersAndPaginate(); };
+
+        const exportProductsToCSV = () => {
+            if (!productData.length) return;
+            const headers = ['ID', 'Nome', 'Tipo', 'Lote', 'Validade', 'Quantidade', 'Custo'];
+            const rows = productData.map(product => [
+                product.id,
+                '"' + product.name.replace(/"/g, '""') + '"',
+                product.type,
+                product.lot,
+                new Date(product.expiryDate).toLocaleDateString('pt-BR', { timeZone: 'UTC' }),
+                product.quantity,
+                product.cost
+            ].join(';'));
+            const csvContent = [headers.join(';'), ...rows].join('\n');
+            const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = `relatorio-estoque-${new Date().toISOString().slice(0, 10)}.csv`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
+        };
+
+        const renderProducts = (products) => {
+            if(!productGrid) return;
+            if (currentView === 'grid') {
+                productGrid.className = 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6';
+            } else {
+                productGrid.className = 'flex flex-col gap-4';
+            }
+            productGrid.innerHTML = '';
+            products.forEach(product => {
+                const stockPercentage = Math.min((product.quantity / 150) * 100, 100);
+                let stockColor = 'bg-green-500';
+                if (stockPercentage < 50) stockColor = 'bg-yellow-500';
+                if (stockPercentage < 25) stockColor = 'bg-red-500';
+                const today = new Date(); today.setHours(0,0,0,0);
+                const expiry = new Date(product.expiryDate);
+                const daysUntilExpiry = Math.ceil((expiry - today) / (1000 * 60 * 60 * 24));
+                const isExpiringSoon = daysUntilExpiry <= 30 && daysUntilExpiry >= 0;
+                const cardElement = document.createElement('div');
+                if (currentView === 'grid') {
+                    cardElement.className = `group relative bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm overflow-hidden transition-transform duration-300 hover:-translate-y-1 flex flex-col ${isExpiringSoon ? 'border-2 border-yellow-400' : ''}`;
+                    cardElement.innerHTML = `
+                        <div class="absolute top-2 left-2 bg-black/50 text-white text-xs font-bold px-2 py-1 rounded-full z-10">${product.type}</div>
+                        ${isExpiringSoon ? `<div class="absolute top-2 right-2 bg-yellow-400 text-yellow-900 rounded-full p-1.5 z-10" title="Vencendo"><span class="material-icons">warning</span></div>` : ''}
+                        <img alt="${product.name}" class="w-full h-40 object-cover" src="${product.image}" />
+                        <div class="p-4 flex-grow flex flex-col">
+                            <h3 class="font-bold">${product.name}</h3>
+                            <div class="mt-2 flex items-center justify-between">
+                                <span class="text-3xl font-bold text-primary">${product.quantity}</span>
+                                <div class="flex items-center text-sm text-subtle-light dark:text-subtle-dark"><span class="material-icons text-base mr-1">calendar_today</span><span>${new Date(product.expiryDate).toLocaleDateString('pt-BR', { timeZone: 'UTC' })}</span></div>
+                            </div>
+                            <div class="mt-auto pt-4"><div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2"><div class="${stockColor} h-2 rounded-full" style="width: ${stockPercentage}%"></div></div></div>
+                        </div>
+                        <div class="absolute inset-0 bg-black bg-opacity-60 flex items-center justify-center space-x-2 card-actions p-2">
+                            <button class="generate-desc-btn bg-secondary text-white p-2 rounded-lg flex-1" title="Gerar Descrição"><span class="material-icons">auto_awesome</span></button>
+                            <button class="edit-btn bg-blue-500 text-white p-2 rounded-lg flex-1" title="Editar"><span class="material-icons">edit</span></button>
+                            <button class="delete-btn bg-danger text-white p-2 rounded-lg flex-1" title="Excluir"><span class="material-icons">delete</span></button>
+                        </div>`;
+                } else {
+                     cardElement.className = `group relative bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm flex items-center p-4 transition-shadow hover:shadow-md`;
+                     cardElement.innerHTML = `
+                        <img alt="${product.name}" class="w-20 h-20 object-cover rounded-lg flex-shrink-0" src="${product.image}" />
+                        <div class="flex-1 ml-4 grid grid-cols-5 items-center gap-4">
+                            <div>
+                                <p class="font-bold">${product.name}</p>
+                                <p class="text-sm text-subtle-light dark:text-subtle-dark">Lote: ${product.lot}</p>
+                            </div>
+                             <div class="text-center">
+                                <span class="text-2xl font-bold text-primary">${product.quantity}</span>
+                                <p class="text-xs text-subtle-light dark:text-subtle-dark">Unidades</p>
+                            </div>
+                            <div class="text-center">
+                                <div class="flex items-center justify-center text-sm text-subtle-light dark:text-subtle-dark">
+                                    <span class="material-icons text-base mr-1">calendar_today</span>
+                                    <span>${new Date(product.expiryDate).toLocaleDateString('pt-BR', { timeZone: 'UTC' })}</span>
+                                </div>
+                                ${isExpiringSoon ? `<p class="text-xs text-yellow-500">Vencendo</p>` : ''}
+                            </div>
+                            <div class="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-2">
+                                <div class="${stockColor} h-2 rounded-full" style="width: ${stockPercentage}%"></div>
+                            </div>
+                            <div class="flex justify-end items-center gap-2">
+                                 <button class="generate-desc-btn bg-secondary text-white p-2 rounded-lg" title="Gerar Descrição"><span class="material-icons text-base">auto_awesome</span></button>
+                                 <button class="edit-btn bg-blue-500 text-white p-2 rounded-lg" title="Editar"><span class="material-icons text-base">edit</span></button>
+                                 <button class="delete-btn bg-danger text-white p-2 rounded-lg" title="Excluir"><span class="material-icons text-base">delete</span></button>
+                            </div>
+                        </div>`;
+                }
+                cardElement.querySelector('.edit-btn').addEventListener('click', () => openEditModal(product.id));
+                cardElement.querySelector('.delete-btn').addEventListener('click', () => openDeleteModal(product.id));
+                cardElement.querySelector('.generate-desc-btn').addEventListener('click', async () => {
+                    const desc = await callGeminiAPI(`Crie uma descrição de marketing curta e apetitosa para "${product.name}".`);
+                    document.getElementById('ai-modal-title').querySelector('span:last-child').textContent = `Marketing para ${product.name}`;
+                    document.getElementById('ai-modal-body').innerHTML = desc;
+                    openModal('ai-modal');
+                });
+                productGrid.appendChild(cardElement);
+            });
+        };
+        const applyFiltersAndPaginate = () => {
+            if(!filterButtonsContainer) return;
+            const searchTerm = searchInput.value.toLowerCase();
+            const activeFilter = filterButtonsContainer.querySelector('.bg-primary')?.dataset.filter || 'all';
+            let filteredProducts = productData.filter(p => p.name.toLowerCase().includes(searchTerm) || p.type.toLowerCase().includes(searchTerm));
+            if (activeFilter === 'low_stock') filteredProducts = filteredProducts.filter(p => p.quantity < 25);
+            if (activeFilter === 'expiring_soon') {
+                const today = new Date(); today.setHours(0,0,0,0);
+                filteredProducts = filteredProducts.filter(p => {
+                     const expiry = new Date(p.expiryDate);
+                     const daysUntilExpiry = Math.ceil((expiry - today) / (1000 * 60 * 60 * 24));
+                     return daysUntilExpiry <= 30 && daysUntilExpiry >= 0;
+                });
+            }
+            currentlyDisplayedProducts = filteredProducts;
+            currentPage = 1;
+            renderPaginatedView();
+        };
+
+        const renderPaginatedView = () => {
+            const startIndex = (currentPage - 1) * itemsPerPage;
+            const endIndex = startIndex + itemsPerPage;
+            const paginatedProducts = currentlyDisplayedProducts.slice(startIndex, endIndex);
+            renderProducts(paginatedProducts);
+            renderPaginationControls();
+        };
+
+        const renderPaginationControls = () => {
+            const paginationContainer = document.getElementById('pagination-controls');
+            if (!paginationContainer) return;
+            const pageCount = Math.ceil(currentlyDisplayedProducts.length / itemsPerPage);
+            paginationContainer.innerHTML = '';
+            if(pageCount <= 1) return;
+            for (let i = 1; i <= pageCount; i++) {
+                const button = document.createElement('button');
+                button.textContent = i;
+                button.className = `px-4 py-2 rounded-lg text-sm font-medium transition-colors ${i === currentPage ? 'bg-primary text-white' : 'bg-surface-light dark:bg-surface-dark hover:bg-gray-200 dark:hover:bg-gray-700'}`;
+                button.onclick = () => {
+                    currentPage = i;
+                    renderPaginatedView();
+                };
+                paginationContainer.appendChild(button);
+            }
+        };
+        const updateHomePage = () => {
+            const totalStock = productData.reduce((sum, p) => sum + p.quantity, 0);
+            const lowStockCount = productData.filter(p => p.quantity < 25).length;
+            const todayMoves = movementsData.filter(m => m.date.toDateString() === new Date().toDateString()).length;
+            const stockValue = productData.reduce((sum, p) => sum + (p.quantity * p.cost), 0);
+            document.getElementById('home-kpi-total-stock').textContent = totalStock.toLocaleString('pt-BR');
+            document.getElementById('home-kpi-low-stock').textContent = lowStockCount;
+            document.getElementById('home-kpi-moves').textContent = todayMoves;
+            document.getElementById('home-kpi-stock-value').textContent = `R$ ${stockValue.toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+            const activityList = document.getElementById('recent-activity-list');
+            activityList.innerHTML = '';
+            activityLog.slice(0, 3).forEach(item => {
+                activityList.innerHTML += `<div class="flex items-center justify-between"><div class="flex items-center gap-4"><div class="bg-${item.color}-100 dark:bg-${item.color}-900/50 p-2 rounded-full"><span class="material-icons text-${item.color}-600 dark:text-${item.color}-400">${item.icon}</span></div><div><p class="font-medium">${item.title}</p><p class="text-sm text-subtle-light dark:text-subtle-dark">${item.subtitle}</p></div></div><p class="text-sm text-subtle-light dark:text-subtle-dark">${item.time}</p></div>`;
+            });
+        };
+        const updateReports = () => {
+            const totalInputs = movementsData.filter(m => m.type === 'input').reduce((sum, m) => sum + m.quantity, 0);
+            const totalOutputs = movementsData.filter(m => m.type === 'output').reduce((sum, m) => sum + m.quantity, 0);
+            const totalStock = productData.reduce((sum, p) => sum + p.quantity, 0);
+            const today = new Date(); today.setHours(0,0,0,0);
+            const expiringCount = productData.filter(p => {
+                const expiry = new Date(p.expiryDate);
+                const daysUntilExpiry = Math.ceil((expiry - today) / (1000 * 60 * 60 * 24));
+                return daysUntilExpiry <= 30 && daysUntilExpiry >= 0;
+            }).length;
+            document.getElementById('kpi-inputs').textContent = totalInputs.toLocaleString('pt-BR');
+            document.getElementById('kpi-outputs').textContent = totalOutputs.toLocaleString('pt-BR');
+            document.getElementById('kpi-total-stock').textContent = `${totalStock} un.`;
+            document.getElementById('kpi-expiring').textContent = expiringCount;
+            updateCharts();
+        };
+        const updateCharts = () => {
+             const chartFont = { family: 'Poppins' };
+            const isDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            const gridColor = isDarkMode ? 'rgba(255, 255, 255, 0.1)' : 'rgba(0, 0, 0, 0.1)';
+            const textColor = isDarkMode ? '#F9FAFB' : '#111827';
+             const labels = productData.map(p => p.name);
+             const data = productData.map(p => p.quantity);
+             const productChartCtx = document.getElementById('stock-by-product-chart');
+             if (productChartCtx) {
+                if(stockByProductChart) stockByProductChart.destroy();
+                const barGradient = productChartCtx.getContext('2d').createLinearGradient(0, 0, 0, productChartCtx.height);
+                barGradient.addColorStop(0, '#6D28D9');
+                barGradient.addColorStop(1, '#9333ea');
+                stockByProductChart = new Chart(productChartCtx, {
+                    type: 'bar',
+                    data: { labels, datasets: [{ label: 'Quantidade', data, backgroundColor: barGradient, borderRadius: 4 }] },
+                    options: {
+                        responsive: true, maintainAspectRatio: false,
+                        plugins: { legend: { display: false }, tooltip: { bodyFont: chartFont, titleFont: chartFont, boxPadding: 8, cornerRadius: 4, backgroundColor: '#1F2937' } },
+                        scales: { y: { ticks: { color: textColor, font: chartFont }, grid: { color: gridColor, drawBorder: false } }, x: { ticks: { color: textColor, font: chartFont }, grid: { display: false } } }
+                    }
+                });
+             }
+             const typeCounts = productData.reduce((acc, p) => { acc[p.type] = (acc[p.type] || 0) + p.quantity; return acc; }, {});
+             const typeChartCtx = document.getElementById('stock-by-type-chart');
+             if(typeChartCtx) {
+                if(stockByTypeChart) stockByTypeChart.destroy();
+                stockByTypeChart = new Chart(typeChartCtx, {
+                    type: 'doughnut',
+                    data: { labels: Object.keys(typeCounts), datasets: [{ data: Object.values(typeCounts), backgroundColor: ['#6D28D9', '#9333ea', '#c084fc', '#e9d5ff'], borderColor: isDarkMode ? '#374151' : '#FFFFFF', borderWidth: 4 }] },
+                    options: {
+                        responsive: true, maintainAspectRatio: false, cutout: '70%',
+                        plugins: { legend: { position: 'bottom', labels: { color: textColor, font: chartFont, boxWidth: 12, padding: 20 } }, tooltip: { bodyFont: chartFont, titleFont: chartFont, boxPadding: 8, cornerRadius: 4, backgroundColor: '#1F2937' } }
+                    }
+                });
+             }
+        };
+        const renderApprovalPage = () => {
+            const pendingList = document.getElementById('pending-users-list');
+            const activeList = document.getElementById('active-users-list');
+            pendingList.innerHTML = '';
+            activeList.innerHTML = '';
+            const pendingUsers = usersData.filter(u => u.status === 'pending');
+            const activeUsers = usersData.filter(u => u.status === 'active');
+            if (pendingUsers.length === 0) {
+                pendingList.innerHTML = `<p class="text-subtle-light dark:text-subtle-dark text-center py-4">Nenhum usuário aguardando aprovação.</p>`;
+            } else {
+                pendingUsers.forEach(user => {
+                    const userEl = document.createElement('div');
+                    userEl.className = 'flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50';
+                    userEl.innerHTML = `
+                        <div class="flex items-center gap-4">
+                            <img src="${user.avatar}" alt="${user.name}" class="w-10 h-10 rounded-full object-cover">
+                            <div><p class="font-semibold">${user.name}</p><p class="text-sm text-subtle-light dark:text-subtle-dark">${user.email}</p></div>
+                        </div>
+                        <div class="flex items-center gap-2">
+                            <button data-user-id="${user.id}" class="approve-user-btn p-2 rounded-full text-green-500 hover:bg-green-100 dark:hover:bg-green-900/50"><span class="material-icons">check_circle</span></button>
+                            <button data-user-id="${user.id}" class="decline-user-btn p-2 rounded-full text-danger hover:bg-red-100 dark:hover:bg-red-900/50"><span class="material-icons">cancel</span></button>
+                        </div>`;
+                    pendingList.appendChild(userEl);
+                });
+            }
+            if (activeUsers.length === 0) {
+                activeList.innerHTML = `<p class="text-subtle-light dark:text-subtle-dark text-center py-4">Nenhum usuário ativo.</p>`;
+            } else {
+                activeUsers.forEach(user => {
+                    const userEl = document.createElement('div');
+                    userEl.className = 'flex items-center justify-between p-3 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700/50';
+                    userEl.innerHTML = `
+                        <div class="flex items-center gap-4">
+                            <img src="${user.avatar}" alt="${user.name}" class="w-10 h-10 rounded-full object-cover">
+                            <div><p class="font-semibold">${user.name}</p><p class="text-sm text-subtle-light dark:text-subtle-dark">${user.email}</p></div>
+                        </div>
+                        <button data-user-id="${user.id}" class="delete-user-btn p-2 rounded-full text-danger hover:bg-red-100 dark:hover:bg-red-900/50"><span class="material-icons">delete</span></button>`;
+                    activeList.appendChild(userEl);
+                });
+            }
+            document.querySelectorAll('.approve-user-btn').forEach(btn => btn.addEventListener('click', () => approveUser(parseInt(btn.dataset.userId))));
+            document.querySelectorAll('.decline-user-btn').forEach(btn => btn.addEventListener('click', () => declineUser(parseInt(btn.dataset.userId))));
+            document.querySelectorAll('.delete-user-btn').forEach(btn => btn.addEventListener('click', () => deleteUser(parseInt(btn.dataset.userId))));
+        };
+        const approveUser = (userId) => { const user = usersData.find(u => u.id === userId); if (user) user.status = 'active'; renderApprovalPage(); };
+        const declineUser = (userId) => { usersData = usersData.filter(u => u.id !== userId); renderApprovalPage(); };
+        const deleteUser = (userId) => { usersData = usersData.filter(u => u.id !== userId); renderApprovalPage(); };
+
+        const setupEventListeners = () => {
+            document.querySelectorAll('.user-menu-button').forEach(button => {
+                button.addEventListener('click', (event) => {
+                    event.stopPropagation();
+                    const dropdown = button.nextElementSibling;
+                    document.querySelectorAll('.user-dropdown-menu').forEach(menu => { if (menu !== dropdown) menu.classList.add('hidden'); });
+                    dropdown.classList.toggle('hidden');
+                });
+            });
+            window.addEventListener('click', (e) => {
+                 document.querySelectorAll('.user-dropdown-menu').forEach(menu => {
+                    const button = menu.previousElementSibling;
+                    if (!button.contains(e.target) && !menu.contains(e.target)) { menu.classList.add('hidden'); }
+                 });
+            });
+            document.querySelectorAll('.profile-link').forEach(link => link.addEventListener('click', (e) => { e.preventDefault(); openProfileModal(); }));
+            document.querySelectorAll('.logout-link').forEach(link => link.addEventListener('click', (e) => { e.preventDefault(); handleLogout(); }));
+            document.querySelectorAll('.approve-link').forEach(link => {
+                link.addEventListener('click', e => {
+                    e.preventDefault();
+                    switchPage(link.dataset.page);
+                    mainMenu.querySelectorAll('a').forEach(item => item.classList.remove('bg-white/20', 'text-white'));
+                    addProductLink.style.display = 'none';
+                });
+            });
+            if(addProductLink) addProductLink.addEventListener('click', e => { e.preventDefault(); openAddModal(); });
+            if(quickAddBtn) quickAddBtn.addEventListener('click', openAddModal);
+            if(quickExportBtn) quickExportBtn.addEventListener('click', exportProductsToCSV);
+            if(saveProfileBtn) saveProfileBtn.addEventListener('click', handleProfileSave);
+            if(addForm) addForm.addEventListener('submit', handleAddSubmit);
+            if(editForm) editForm.addEventListener('submit', handleEditSubmit);
+            if(confirmDeleteBtn) confirmDeleteBtn.addEventListener('click', handleDeleteConfirm);
+            if(searchInput) searchInput.addEventListener('input', applyFiltersAndPaginate);
+            mainMenu.addEventListener('click', (e) => {
+                const link = e.target.closest('a');
+                if (link && link.dataset.page) {
+                    e.preventDefault();
+                    mainMenu.querySelectorAll('a').forEach(item => { item.classList.remove('bg-white/20', 'text-white'); item.classList.add('text-white/70', 'hover:bg-white/10'); });
+                    link.classList.add('bg-white/20', 'text-white');
+                    link.classList.remove('text-white/70', 'hover:bg-white/10');
+                    addProductLink.style.display = link.id === 'stock-menu-item' ? 'flex' : 'none';
+                    switchPage(link.dataset.page);
+                }
+            });
+            document.querySelectorAll('[data-close-modal]').forEach(btn => btn.addEventListener('click', () => closeModal(btn.dataset.closeModal)));
+            if (filterButtonsContainer) {
+                filterButtonsContainer.addEventListener('click', (e) => {
+                    const button = e.target.closest('button');
+                    if(button) {
+                        filterButtonsContainer.querySelector('.bg-primary')?.classList.remove('bg-primary', 'text-white');
+                        button.classList.add('bg-primary', 'text-white');
+                        applyFiltersAndPaginate();
+                    }
+                });
+            }
+            if(suggestProductBtn) {
+                suggestProductBtn.addEventListener('click', async () => {
+                    const existing = productData.map(p => p.name).join(', ');
+                    const suggestion = await callGeminiAPI(`Baseado em: ${existing}, sugira 3 novos sabores de açaí com nomes criativos.`);
+                    document.getElementById('ai-modal-title').querySelector('span:last-child').textContent = 'Sugestão de Produtos';
+                    document.getElementById('ai-modal-body').innerHTML = suggestion;
+                    openModal('ai-modal');
+                });
+            }
+            if (aiAnalysisBtn) {
+                aiAnalysisBtn.addEventListener('click', async () => {
+                    const summary = `Estoque total: ${document.getElementById('kpi-total-stock').textContent}, Itens vencendo: ${document.getElementById('kpi-expiring').textContent}, Entradas: ${document.getElementById('kpi-inputs').textContent}, Saídas: ${document.getElementById('kpi-outputs').textContent}.`;
+                    const analysis = await callGeminiAPI(`Sou dono de uma loja de açaí. Baseado neste resumo do meu estoque (${summary}), me dê um insight e uma sugestão para otimizar meu negócio.`);
+                    document.getElementById('ai-modal-title').querySelector('span:last-child').textContent = 'Análise de Relatório';
+                    document.getElementById('ai-modal-body').innerHTML = analysis;
+                    openModal('ai-modal');
+                });
+            }
+            if(gridViewBtn && listViewBtn){
+                 gridViewBtn.addEventListener('click', () => {
+                    currentView = 'grid';
+                    gridViewBtn.classList.add('bg-primary', 'text-white');
+                    listViewBtn.classList.remove('bg-primary', 'text-white');
+                    applyFiltersAndPaginate();
+                });
+                listViewBtn.addEventListener('click', () => {
+                    currentView = 'list';
+                    listViewBtn.classList.add('bg-primary', 'text-white');
+                    gridViewBtn.classList.remove('bg-primary', 'text-white');
+                    applyFiltersAndPaginate();
+                });
+            }
+        };
+        setupImagePreview('add-image', 'add-image-preview');
+        setupImagePreview('edit-image', 'edit-image-preview');
+        setupImagePreview('profile-image-upload', 'profile-modal-image');
+        setupEventListeners();
+        document.querySelector('#home-menu-item').click();
+        if(filterButtonsContainer) {
+            filterButtonsContainer.querySelector('[data-filter="all"]').classList.add('bg-primary', 'text-white');
+        }
+        if(gridViewBtn) {
+            gridViewBtn.classList.add('bg-primary', 'text-white');
+        }
+        applyFiltersAndPaginate();
+    });
+</script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="utf-8" />
+    <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+    <title>Login - Açaí da Barra</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <script>
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        primary: "#6D28D9",
+                        "background-light": "#F9FAFB",
+                        "background-dark": "#1F2937",
+                        "surface-light": "#FFFFFF",
+                        "surface-dark": "#374151",
+                        "text-light": "#111827",
+                        "text-dark": "#F9FAFB",
+                        "secondary-text-light": "#6B7280",
+                        "secondary-text-dark": "#D1D5DB",
+                        danger: "#EF4444"
+                    },
+                    fontFamily: {
+                        display: ["Poppins", "sans-serif"],
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.75rem",
+                    },
+                },
+            },
+        };
+    </script>
+    <style>
+        .material-icons {
+            vertical-align: middle;
+        }
+    </style>
+</head>
+<body class="bg-background-light dark:bg-background-dark font-display min-h-screen">
+    <div class="flex flex-col md:flex-row min-h-screen">
+        <div class="w-full md:w-1/2 bg-[#D4F4D4] dark:bg-purple-900/20 flex items-center justify-center p-8 md:p-12 transition-all duration-300">
+            <div class="text-center">
+                <img alt="Mascote roxo de um olho só, sorrindo e usando um boné branco com a logo Açaí da Barra" class="max-w-xs md:max-w-md lg:max-w-lg mx-auto transform hover:scale-105 transition-transform duration-500" src="https://lh3.googleusercontent.com/aida-public/AB6AXuAFeM1Bzl4h11sKPp-1UZnnFsOHnJoG00VjHEcTfTxQG0GAa1JRc4aALHBcOuCQsGfG6_-isEthzrb6bVpgG6CVCuoILmX5a7Qgfi5r2yirPZ0tnPKL8_p3k4fgQTc24XLG3jrnYVVFOQV-iZX03bwLd6YqELZzhqGrMWOzxP7uWcFbPHt8pzv-B9sBIHbxcqiowAM1uR_7fZesonMaFNGkrms_G3dIpEhUsIUyaTiJuKq-fOoG5tAwHvFBvhOXVyplc6Fw89W6PRzI" />
+                <div class="mt-8 text-center hidden md:block">
+                    <h2 class="text-2xl font-bold text-text-light dark:text-text-dark">A energia que você precisa!</h2>
+                    <p class="mt-2 text-secondary-text-light dark:text-secondary-text-dark">Faça login e peça o melhor açaí da região.</p>
+                </div>
+            </div>
+        </div>
+        <div class="w-full md:w-1/2 flex items-center justify-center p-6 md:p-12 bg-surface-light dark:bg-surface-dark">
+            <div class="w-full max-w-md space-y-8">
+                <div class="text-center md:text-left">
+                    <h1 class="text-4xl font-bold text-primary">Bem-vindo de volta!</h1>
+                    <p class="mt-2 text-lg text-secondary-text-light dark:text-secondary-text-dark">Acesse sua conta para continuar.</p>
+                </div>
+                <div id="login-feedback" class="hidden rounded-DEFAULT border border-danger/20 bg-danger/10 px-4 py-3 text-sm text-danger" role="alert" aria-live="assertive"></div>
+                <form id="login-form" class="space-y-6" novalidate>
+                    <div>
+                        <label class="block text-sm font-medium text-text-light dark:text-text-dark mb-2" for="username">Nome de Usuário (Login)</label>
+                        <div class="relative rounded-md shadow-sm">
+                            <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                                <i class="material-icons text-gray-400">person_outline</i>
+                            </span>
+                            <input class="block w-full rounded-DEFAULT border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark pl-10 focus:border-primary focus:ring-primary sm:text-sm py-3 text-text-light dark:text-text-dark" id="username" name="username" placeholder="Digite seu usuário" type="text" autocomplete="username" required />
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-text-light dark:text-text-dark mb-2" for="password">Senha de Acesso</label>
+                        <div class="relative rounded-md shadow-sm">
+                            <span class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+                                <i class="material-icons text-gray-400">lock_outline</i>
+                            </span>
+                            <input class="block w-full rounded-DEFAULT border-gray-300 dark:border-gray-600 bg-background-light dark:bg-background-dark pl-10 pr-10 focus:border-primary focus:ring-primary sm:text-sm py-3 text-text-light dark:text-text-dark" id="password" name="password" placeholder="Digite sua senha" type="password" autocomplete="current-password" required />
+                            <button class="absolute inset-y-0 right-0 flex items-center pr-3 cursor-pointer" id="toggle-password-btn" type="button" aria-label="Mostrar ou ocultar senha">
+                                <i class="material-icons text-gray-400 hover:text-primary" id="eye-icon">visibility_off</i>
+                            </button>
+                        </div>
+                    </div>
+                    <div class="flex items-center justify-between">
+                        <div class="flex items-center">
+                            <input class="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary" id="remember-me" name="remember-me" type="checkbox" />
+                            <label class="ml-2 block text-sm text-secondary-text-light dark:text-secondary-text-dark" for="remember-me">Lembrar-me</label>
+                        </div>
+                        <div class="text-sm">
+                            <a class="font-medium text-primary hover:text-primary/80" href="#">Esqueceu sua senha?</a>
+                        </div>
+                    </div>
+                    <div class="flex flex-col space-y-4">
+                        <button id="submit-button" class="w-full flex justify-center py-3 px-4 border border-transparent rounded-DEFAULT shadow-sm text-sm font-medium text-white bg-primary hover:bg-primary/90 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-all duration-300 transform hover:scale-105 disabled:opacity-60 disabled:hover:scale-100 disabled:cursor-not-allowed" type="submit">
+                            Entrar
+                        </button>
+                        <button id="create-account-btn" class="w-full flex justify-center py-3 px-4 border border-gray-300 dark:border-gray-600 rounded-DEFAULT shadow-sm text-sm font-medium text-primary bg-transparent hover:bg-primary/10 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary transition-all duration-300" type="button">
+                            Ainda não tem uma conta? Cadastre-se
+                        </button>
+                    </div>
+                </form>
+                <div class="text-center md:hidden mt-8">
+                    <h2 class="text-xl font-bold text-text-light dark:text-text-dark">A energia que você precisa!</h2>
+                    <p class="mt-1 text-sm text-secondary-text-light dark:text-secondary-text-dark">Peça o melhor açaí da região.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+    <script>
+        const togglePassword = () => {
+            const passwordInput = document.getElementById('password');
+            const eyeIcon = document.getElementById('eye-icon');
+            if (passwordInput.type === 'password') {
+                passwordInput.type = 'text';
+                eyeIcon.innerText = 'visibility';
+            } else {
+                passwordInput.type = 'password';
+                eyeIcon.innerText = 'visibility_off';
+            }
+        };
+
+        document.addEventListener('DOMContentLoaded', () => {
+            const storedUserString = sessionStorage.getItem('acai-user') || localStorage.getItem('acai-user');
+            if (storedUserString) {
+                window.location.replace('index.html');
+                return;
+            }
+
+            const togglePasswordBtn = document.getElementById('toggle-password-btn');
+            const loginForm = document.getElementById('login-form');
+            const feedback = document.getElementById('login-feedback');
+            const submitButton = document.getElementById('submit-button');
+            const rememberMe = document.getElementById('remember-me');
+            const usernameInput = document.getElementById('username');
+            const passwordInput = document.getElementById('password');
+            const createAccountBtn = document.getElementById('create-account-btn');
+
+            togglePasswordBtn.addEventListener('click', togglePassword);
+            createAccountBtn.addEventListener('click', () => {
+                feedback.classList.remove('hidden');
+                feedback.textContent = 'Entre em contato com o administrador para criar uma nova conta.';
+            });
+
+            const setLoading = (isLoading) => {
+                submitButton.disabled = isLoading;
+                submitButton.innerText = isLoading ? 'Entrando...' : 'Entrar';
+            };
+
+            loginForm.addEventListener('submit', async (event) => {
+                event.preventDefault();
+                feedback.classList.add('hidden');
+                feedback.textContent = '';
+
+                const username = usernameInput.value.trim();
+                const password = passwordInput.value;
+
+                if (!username || !password) {
+                    feedback.textContent = 'Informe usuário e senha para continuar.';
+                    feedback.classList.remove('hidden');
+                    return;
+                }
+
+                setLoading(true);
+                try {
+                    const response = await fetch('/api/login', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ username, password })
+                    });
+                    const data = await response.json();
+                    if (!response.ok) {
+                        throw new Error(data?.error || 'Não foi possível realizar o login.');
+                    }
+
+                    const userData = {
+                        id: data.userId,
+                        username,
+                        role: data.role || 'user',
+                        photo: data.photo || null
+                    };
+                    sessionStorage.setItem('acai-user', JSON.stringify(userData));
+                    if (rememberMe.checked) {
+                        localStorage.setItem('acai-user', JSON.stringify(userData));
+                    } else {
+                        localStorage.removeItem('acai-user');
+                    }
+
+                    window.location.href = 'index.html';
+                } catch (error) {
+                    feedback.textContent = error.message;
+                    feedback.classList.remove('hidden');
+                } finally {
+                    setLoading(false);
+                }
+            });
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- adicionar uma página de login responsiva que consome o endpoint `/api/login`, oferece feedback de erro e opção de lembrar acesso
- personalizar o painel principal com os dados do usuário autenticado, incluindo saudação, avatar dinâmico e ação de sair
- sincronizar a foto e as informações do usuário entre sessionStorage/localStorage e redirecionar visitantes não autenticados para o login

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d58b09be1c832a9c655a852b35dbcc