### PR TITLE
Fix stock filters and pagination behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,6 +259,9 @@
                                     <button data-filter="low_stock" class="filter-btn px-4 py-2 rounded-lg text-sm font-medium">Estoque Baixo</button>
                                     <button data-filter="expiring_soon" class="filter-btn px-4 py-2 rounded-lg text-sm font-medium">Vencendo</button>
                                 </div>
+                                <button id="clear-filters-btn" class="px-4 py-2 rounded-lg text-sm font-medium bg-gray-200 dark:bg-gray-600 hover:bg-gray-300 dark:hover:bg-gray-500 transition-colors">
+                                    Limpar filtros
+                                </button>
                                 <div class="flex items-center border border-gray-300 dark:border-gray-700 rounded-lg">
                                     <button id="grid-view-btn" class="p-2"><span class="material-icons">grid_view</span></button>
                                     <button id="list-view-btn" class="p-2"><span class="material-icons">view_list</span></button>


### PR DESCRIPTION
## Summary
- add a dedicated button to clear filters and make the "Todos" option reset the search for a full product list
- clamp pagination to available products, hide it when unnecessary, and show feedback when no products match
- allow local environments to call the API via same-origin requests for easier testing

## Testing
- Manual: Verified filters, clear action, and pagination navigation in the stock page

------
https://chatgpt.com/codex/tasks/task_e_68d5e20efa50832a887bf10b603557c5