### PR TITLE
Adjust stock filters layout and grid alignment

### DIFF
--- a/estilos.css
+++ b/estilos.css
@@ -899,6 +899,17 @@ tbody tr.removing {
     gap: 10px;
 }
 
+/* Ajustes específicos da página de estoque moderna */
+#product-container {
+    display: flex;
+    flex-direction: column;
+}
+
+#product-grid {
+    align-content: flex-start;
+    align-items: flex-start;
+}
+
 .charts-grid {
     display: flex;
     flex-wrap: wrap;

--- a/index.html
+++ b/index.html
@@ -247,7 +247,7 @@
                             </div>
                         </div>
                     </header>
-                    <div class="flex-1 p-6 bg-surface-light dark:bg-surface-dark overflow-y-auto">
+                    <div class="p-6 bg-surface-light dark:bg-surface-dark">
                         <div class="flex flex-col md:flex-row md:items-center md:justify-between space-y-4 md:space-y-0 gap-4">
                             <div class="relative flex-1 md:max-w-md">
                                 <span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">search</span>
@@ -270,7 +270,7 @@
                         </div>
                     </div>
                     <div id="product-container" class="flex-1 p-6 overflow-y-auto bg-background-light dark:bg-background-dark flex flex-col">
-                        <div id="product-grid" class="flex-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6"></div>
+                        <div id="product-grid" class="flex-1 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6 content-start"></div>
                         <div id="pagination-controls" class="flex justify-center items-center mt-8 space-x-2"></div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- remove the extra flex growth from the stock filters wrapper so the product list starts immediately after the filters
- ensure the product grid aligns its content to the top to avoid extra whitespace

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d5e7f7e40c832aa7c3f8e37b5ea7ee