### PR TITLE
Reduce edit modal dimensions

### DIFF
--- a/index.html
+++ b/index.html
@@ -494,7 +494,7 @@
     </div>
 
     <div id="edit-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 hidden">
-        <div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-xl w-full max-w-lg">
+        <div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-xl w-full max-w-md">
             <header class="flex items-center justify-between p-4 border-b dark:border-gray-700">
                 <h2 class="text-xl font-bold flex items-center gap-2">
                     <span class="material-icons">edit</span>
@@ -505,7 +505,7 @@
                 </button>
             </header>
             <form id="edit-form">
-                <main class="p-6 space-y-4">
+                <main class="p-4 space-y-4">
                     <input type="hidden" id="edit-id" name="id">
                     <label class="block text-sm font-medium">Imagem
                         <input type="file" name="image" id="edit-image" class="w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-violet-50 file:text-primary hover:file:bg-violet-100">


### PR DESCRIPTION
## Summary
- reduce the edit modal's maximum width for a more compact layout
- tighten the modal's internal padding to match the smaller footprint

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d5f7135030832ab0c5d17464b70dae