### PR TITLE
Refine product modals to match provided design

### DIFF
--- a/estilos.css
+++ b/estilos.css
@@ -464,6 +464,214 @@ header h1 {
     background-color: #bbb;
 }
 
+/* ===== MODAIS DE FORMULÁRIO (ADICIONAR/EDITAR) ===== */
+
+.product-modal__overlay {
+    --product-modal-gap: clamp(32px, 6vh, 72px);
+    padding: var(--product-modal-gap);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.product-modal {
+    width: min(100%, 420px);
+    background: #ffffff;
+    border-radius: 20px;
+    box-shadow: 0 28px 60px rgba(15, 23, 42, 0.18);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - var(--product-modal-gap, 48px) * 2);
+    overflow-y: auto;
+}
+
+.product-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 24px;
+    background: #ffffff;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.product-modal__title {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 0;
+    font-size: 1.15rem;
+    font-weight: 600;
+    color: #1f2937;
+}
+
+.product-modal__icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 999px;
+    background: #ede9fe;
+    color: #6d28d9;
+    font-size: 24px;
+}
+
+.product-modal__close {
+    border: none;
+    background: transparent;
+    width: 40px;
+    height: 40px;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #4b5563;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.product-modal__close:hover {
+    background: #f3f4f6;
+    color: #111827;
+}
+
+.product-modal__body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 24px;
+    background: #ffffff;
+}
+
+.product-modal__field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.product-modal__label {
+    font-size: 0.85rem;
+    font-weight: 500;
+    color: #4b5563;
+}
+
+.product-modal__control {
+    border: 1px solid #e5e7eb;
+    border-radius: 12px;
+    background: #f9fafb;
+    padding: 0.7rem 0.9rem;
+    font-size: 0.95rem;
+    color: #111827;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.product-modal__control:focus {
+    outline: none;
+    border-color: #6d28d9;
+    background: #ffffff;
+    box-shadow: 0 0 0 3px rgba(109, 40, 217, 0.18);
+}
+
+.product-modal__control--file {
+    padding: 0.55rem 0.9rem;
+    background: #ffffff;
+    border-style: dashed;
+    border-color: rgba(109, 40, 217, 0.3);
+}
+
+.product-modal__control--file::file-selector-button {
+    border: none;
+    border-radius: 999px;
+    background: #6d28d9;
+    color: #ffffff;
+    font-weight: 600;
+    padding: 0.55rem 1.4rem;
+    margin-right: 12px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.product-modal__control--file::file-selector-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 12px 22px rgba(109, 40, 217, 0.25);
+    background: #7c3aed;
+}
+
+.product-modal__preview {
+    width: 88px;
+    height: 88px;
+    border-radius: 14px;
+    object-fit: cover;
+    border: 2px solid rgba(148, 163, 184, 0.5);
+}
+
+.product-modal__field-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+}
+
+.product-modal__footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 12px;
+    padding: 18px 24px 24px;
+    background: #f9fafb;
+    border-top: 1px solid #e5e7eb;
+}
+
+.product-modal__btn {
+    border: none;
+    border-radius: 12px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    padding: 0.7rem 1.4rem;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+    font-family: 'Poppins', sans-serif;
+}
+
+.product-modal__btn--ghost {
+    background: transparent;
+    color: #4b5563;
+}
+
+.product-modal__btn--ghost:hover {
+    background: #e5e7eb;
+    color: #1f2937;
+}
+
+.product-modal__btn--primary {
+    background: #6d28d9;
+    color: #ffffff;
+    box-shadow: 0 12px 24px rgba(109, 40, 217, 0.3);
+}
+
+.product-modal__btn--primary:hover {
+    background: #7c3aed;
+    box-shadow: 0 16px 28px rgba(109, 40, 217, 0.35);
+}
+
+@media (max-width: 540px) {
+    .product-modal {
+        width: min(100%, 360px);
+        border-radius: 18px;
+    }
+
+    .product-modal__body {
+        padding: 20px;
+    }
+
+    .product-modal__footer {
+        padding: 18px 20px 22px;
+    }
+
+    .product-modal__field-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
 /* ===== MELHORIAS DA INTERFACE DA TABELA ===== */
 
 /* Container da tabela com sombra e bordas arredondadas */

--- a/index.html
+++ b/index.html
@@ -445,98 +445,110 @@
         </div>
     </div>
 
-    <div id="add-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 hidden">
-        <div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-xl w-full max-w-lg">
-            <header class="flex items-center justify-between p-4 border-b dark:border-gray-700">
-                <h2 class="text-xl font-bold flex items-center gap-2">
-                    <span class="material-icons">add_circle</span>
-                    <span>Adicionar Produto</span>
+    <div id="add-modal" class="product-modal__overlay fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center hidden">
+        <div class="product-modal">
+            <header class="product-modal__header">
+                <h2 class="product-modal__title">
+                    <span class="material-icons product-modal__icon">add_circle</span>
+                    <span>Adicionar produto</span>
                 </h2>
-                <button data-close-modal="add-modal" class="p-2 rounded-full">
+                <button data-close-modal="add-modal" class="product-modal__close" aria-label="Fechar modal de adição">
                     <span class="material-icons">close</span>
                 </button>
             </header>
             <form id="add-form">
-                <main class="p-6 space-y-4">
-                    <label class="block text-sm font-medium">Imagem
-                        <input type="file" name="image" id="add-image" class="w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-violet-50 file:text-primary hover:file:bg-violet-100">
-                        <img id="add-image-preview" src="https://placehold.co/100x100/E2E8F0/4A5568?text=Preview" alt="Preview" class="mt-2 rounded-md h-24 w-24 object-cover hidden">
+                <main class="product-modal__body">
+                    <label class="product-modal__field">
+                        <span class="product-modal__label">Imagem</span>
+                        <input type="file" name="image" id="add-image" class="product-modal__control product-modal__control--file">
+                        <img id="add-image-preview" src="https://placehold.co/100x100/E2E8F0/4A5568?text=Preview" alt="Pré-visualização da imagem" class="product-modal__preview hidden">
                     </label>
-                    <label class="block text-sm font-medium">Tipo
-                        <select name="type" id="add-type" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark">
+                    <label class="product-modal__field">
+                        <span class="product-modal__label">Tipo</span>
+                        <select name="type" id="add-type" required class="product-modal__control">
                             <option value="Açaí">Açaí</option>
                             <option value="Sorvete">Sorvete</option>
                             <option value="Complemento">Complemento</option>
                             <option value="Bebida">Bebida</option>
                         </select>
                     </label>
-                    <label class="block text-sm font-medium">Nome
-                        <input type="text" name="name" id="add-name" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark">
+                    <label class="product-modal__field">
+                        <span class="product-modal__label">Nome</span>
+                        <input type="text" name="name" id="add-name" required class="product-modal__control">
                     </label>
-                    <label class="block text-sm font-medium">Lote
-                        <input type="text" name="lot" id="add-lot" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark">
+                    <label class="product-modal__field">
+                        <span class="product-modal__label">Lote</span>
+                        <input type="text" name="lot" id="add-lot" required class="product-modal__control">
                     </label>
-                    <div class="grid grid-cols-2 gap-4">
-                        <label class="block text-sm font-medium">Quantidade
-                            <input type="number" name="quantity" id="add-quantity" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark" min="0">
+                    <div class="product-modal__field-grid">
+                        <label class="product-modal__field">
+                            <span class="product-modal__label">Quantidade</span>
+                            <input type="number" name="quantity" id="add-quantity" required class="product-modal__control" min="0">
                         </label>
-                        <label class="block text-sm font-medium">Validade
-                            <input type="date" name="expiryDate" id="add-expiryDate" class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark">
+                        <label class="product-modal__field">
+                            <span class="product-modal__label">Validade</span>
+                            <input type="date" name="expiryDate" id="add-expiryDate" class="product-modal__control">
                         </label>
                     </div>
                 </main>
-                <footer class="flex justify-end p-4 bg-gray-50 dark:bg-gray-800 space-x-2">
-                    <button type="button" data-close-modal="add-modal" class="px-4 py-2 rounded-lg">Cancelar</button>
-                    <button type="submit" class="px-4 py-2 bg-primary text-white rounded-lg">Adicionar</button>
+                <footer class="product-modal__footer">
+                    <button type="button" data-close-modal="add-modal" class="product-modal__btn product-modal__btn--ghost">Cancelar</button>
+                    <button type="submit" class="product-modal__btn product-modal__btn--primary">Adicionar</button>
                 </footer>
             </form>
         </div>
     </div>
 
-    <div id="edit-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4 hidden">
-        <div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-xl w-full max-w-lg">
-            <header class="flex items-center justify-between p-4 border-b dark:border-gray-700">
-                <h2 class="text-xl font-bold flex items-center gap-2">
-                    <span class="material-icons">edit</span>
-                    <span>Editar Produto</span>
+    <div id="edit-modal" class="product-modal__overlay fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center hidden">
+        <div class="product-modal">
+            <header class="product-modal__header">
+                <h2 class="product-modal__title">
+                    <span class="material-icons product-modal__icon">edit</span>
+                    <span>Editar produto</span>
                 </h2>
-                <button data-close-modal="edit-modal" class="p-2 rounded-full">
+                <button data-close-modal="edit-modal" class="product-modal__close" aria-label="Fechar modal de edição">
                     <span class="material-icons">close</span>
                 </button>
             </header>
             <form id="edit-form">
-                <main class="p-6 space-y-4">
+                <main class="product-modal__body">
                     <input type="hidden" id="edit-id" name="id">
-                    <label class="block text-sm font-medium">Imagem
-                        <input type="file" name="image" id="edit-image" class="w-full text-sm file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:font-semibold file:bg-violet-50 file:text-primary hover:file:bg-violet-100">
-                        <img id="edit-image-preview" src="https://placehold.co/100x100/E2E8F0/4A5568?text=Preview" alt="Preview" class="mt-2 rounded-md h-24 w-24 object-cover hidden">
+                    <label class="product-modal__field">
+                        <span class="product-modal__label">Imagem</span>
+                        <input type="file" name="image" id="edit-image" class="product-modal__control product-modal__control--file">
+                        <img id="edit-image-preview" src="https://placehold.co/100x100/E2E8F0/4A5568?text=Preview" alt="Pré-visualização da imagem" class="product-modal__preview hidden">
                     </label>
-                    <label class="block text-sm font-medium">Tipo
-                        <select name="type" id="edit-type" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark">
+                    <label class="product-modal__field">
+                        <span class="product-modal__label">Tipo</span>
+                        <select name="type" id="edit-type" required class="product-modal__control">
                             <option value="Açaí">Açaí</option>
                             <option value="Sorvete">Sorvete</option>
                             <option value="Complemento">Complemento</option>
                             <option value="Bebida">Bebida</option>
                         </select>
                     </label>
-                    <label class="block text-sm font-medium">Nome
-                        <input type="text" name="name" id="edit-name" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark">
+                    <label class="product-modal__field">
+                        <span class="product-modal__label">Nome</span>
+                        <input type="text" name="name" id="edit-name" required class="product-modal__control">
                     </label>
-                    <label class="block text-sm font-medium">Lote
-                        <input type="text" name="lot" id="edit-lot" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark">
+                    <label class="product-modal__field">
+                        <span class="product-modal__label">Lote</span>
+                        <input type="text" name="lot" id="edit-lot" required class="product-modal__control">
                     </label>
-                    <div class="grid grid-cols-2 gap-4">
-                        <label class="block text-sm font-medium">Quantidade
-                            <input type="number" name="quantity" id="edit-quantity" required class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark" min="0">
+                    <div class="product-modal__field-grid">
+                        <label class="product-modal__field">
+                            <span class="product-modal__label">Quantidade</span>
+                            <input type="number" name="quantity" id="edit-quantity" required class="product-modal__control" min="0">
                         </label>
-                        <label class="block text-sm font-medium">Validade
-                            <input type="date" name="expiryDate" id="edit-expiryDate" class="w-full border rounded-lg p-2 bg-background-light dark:bg-background-dark">
+                        <label class="product-modal__field">
+                            <span class="product-modal__label">Validade</span>
+                            <input type="date" name="expiryDate" id="edit-expiryDate" class="product-modal__control">
                         </label>
                     </div>
                 </main>
-                <footer class="flex justify-end p-4 bg-gray-50 dark:bg-gray-800 space-x-2">
-                    <button type="button" data-close-modal="edit-modal" class="px-4 py-2 rounded-lg">Cancelar</button>
-                    <button type="submit" class="px-4 py-2 bg-primary text-white rounded-lg">Salvar</button>
+                <footer class="product-modal__footer">
+                    <button type="button" data-close-modal="edit-modal" class="product-modal__btn product-modal__btn--ghost">Cancelar</button>
+                    <button type="submit" class="product-modal__btn product-modal__btn--primary">Salvar</button>
                 </footer>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- rebuild the add and edit product modal markup to follow the provided design structure and naming
- refresh the modal styling with the new product-modal system so spacing, buttons, and responsive behavior match the sample layout

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d5f7135030832ab0c5d17464b70dae