### PR TITLE
Improve responsive layout and navigation

### DIFF
--- a/estilos.css
+++ b/estilos.css
@@ -25,6 +25,108 @@ body {
     min-height: 100dvh;
 }
 
+body.sidebar-locked {
+    overflow: hidden;
+    position: relative;
+    touch-action: none;
+}
+
+/* ===== APLICAÇÃO PRINCIPAL ===== */
+
+.app-shell {
+    display: flex;
+    min-height: 100dvh;
+    background: var(--background-app, transparent);
+    position: relative;
+}
+
+.app-sidebar {
+    width: min(18rem, 85vw);
+    display: flex;
+    flex-direction: column;
+    position: fixed;
+    inset: 0 auto 0 0;
+    transform: translateX(-100%);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    z-index: 40;
+    box-shadow: 0 20px 45px rgba(52, 0, 82, 0.35);
+    backdrop-filter: blur(8px);
+    pointer-events: none;
+    max-height: 100dvh;
+}
+
+.app-sidebar nav {
+    padding-bottom: 2.5rem;
+    flex: 1 1 auto;
+    overflow-y: auto;
+}
+
+.app-sidebar[data-open="true"] {
+    transform: translateX(0);
+    pointer-events: auto;
+}
+
+#main-content {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: 100%;
+}
+
+.app-sidebar-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(17, 24, 39, 0.4);
+    backdrop-filter: blur(2px);
+    z-index: 30;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.app-sidebar-backdrop[data-visible="true"] {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.mobile-menu-toggle,
+.mobile-menu-close {
+    line-height: 0;
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.mobile-menu-toggle:focus-visible,
+.mobile-menu-close:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.55);
+    outline-offset: 2px;
+}
+
+@media (min-width: 640px) {
+    .app-shell {
+        background: transparent;
+    }
+
+    .app-sidebar {
+        position: static;
+        transform: none !important;
+        width: clamp(15rem, 18vw, 19rem);
+        box-shadow: none;
+        pointer-events: auto;
+        backdrop-filter: none;
+        max-height: none;
+    }
+
+    .app-sidebar nav {
+        padding-bottom: 1.5rem;
+        overflow: visible;
+    }
+
+    .app-sidebar-backdrop {
+        display: none !important;
+    }
+}
+
 img,
 picture,
 svg,

--- a/index.html
+++ b/index.html
@@ -116,13 +116,16 @@
 
     <!-- Aplicação -->
     <div id="app-container" class="hidden">
-        <div class="flex h-screen">
+        <div class="app-shell bg-background-light dark:bg-background-dark">
             <!-- Sidebar -->
-            <aside class="w-64 bg-primary text-white flex-col hidden sm:flex">
-                <div class="px-6 py-8 flex items-center">
+            <aside id="sidebar" class="app-sidebar bg-primary text-white" aria-label="Menu principal">
+                <div class="px-6 py-8 flex items-center justify-between">
                     <h1 class="text-2xl font-bold">AçaíStock</h1>
+                    <button type="button" class="mobile-menu-close sm:hidden p-2 rounded-full hover:bg-primary/80 transition" aria-label="Fechar menu">
+                        <span class="material-icons">close</span>
+                    </button>
                 </div>
-                <nav id="main-menu" class="flex-1 px-4 space-y-2">
+                <nav id="main-menu" class="flex-1 px-4 space-y-2 overflow-y-auto">
                     <a id="home-menu-item" data-page="home-page" class="flex items-center gap-4 px-4 py-3 rounded-lg" href="#">
                         <span class="material-icons">dashboard</span>
                         <span class="font-medium">Início</span>
@@ -145,6 +148,7 @@
                     </a>
                 </nav>
             </aside>
+            <div id="sidebar-backdrop" class="app-sidebar-backdrop"></div>
 
             <!-- Main Content -->
             <div id="main-content" class="flex-1 flex flex-col overflow-hidden min-h-0">
@@ -152,9 +156,14 @@
                 <!-- Home Page -->
                 <div id="home-page" class="page-content flex-1 flex flex-col min-h-0">
                     <header class="flex items-center justify-between p-6 bg-surface-light dark:bg-surface-dark border-b border-gray-200 dark:border-gray-700">
-                        <div>
+                        <div class="flex items-center gap-3">
+                            <button type="button" class="mobile-menu-toggle sm:hidden p-2 rounded-full border border-white/30 bg-primary/90 text-white shadow-md" aria-label="Abrir menu" aria-controls="sidebar">
+                                <span class="material-icons">menu</span>
+                            </button>
+                            <div>
                             <h2 class="text-2xl font-bold">Dashboard</h2>
                             <p class="text-subtle-light dark:text-subtle-dark" id="home-greeting">Bem-vindo!</p>
+                            </div>
                         </div>
                         <div class="relative">
                             <button class="user-menu-button flex items-center gap-3 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
@@ -234,7 +243,12 @@
                 <!-- Stock Page -->
                 <div id="stock-page" class="page-content flex-1 flex flex-col hidden min-h-0">
                     <header class="flex justify-between items-center p-6 bg-surface-light dark:bg-surface-dark border-b dark:border-gray-700">
-                        <h1 class="text-2xl font-bold">Estoque</h1>
+                        <div class="flex items-center gap-3">
+                            <button type="button" class="mobile-menu-toggle sm:hidden p-2 rounded-full border border-white/30 bg-primary/90 text-white shadow-md" aria-label="Abrir menu" aria-controls="sidebar">
+                                <span class="material-icons">menu</span>
+                            </button>
+                            <h1 class="text-2xl font-bold">Estoque</h1>
+                        </div>
                         <div class="relative">
                             <button class="user-menu-button flex items-center gap-3 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                                 <img src="https://placehold.co/40x40/6D28D9/FFFFFF?text=U" alt="Avatar do Usuário" class="user-avatar-img w-10 h-10 rounded-full object-cover" loading="lazy" decoding="async" data-fallback-src="img/placeholders/avatar-placeholder.svg" onerror="if(!this.dataset.fallbackApplied){this.dataset.fallbackApplied='true';this.src=this.dataset.fallbackSrc;}">
@@ -280,7 +294,12 @@
                 <!-- Reports Page -->
                 <div id="reports-page" class="page-content hidden flex-1 flex flex-col min-h-0">
                     <header class="flex justify-between items-center p-6 bg-surface-light dark:bg-surface-dark border-b dark:border-gray-700">
-                        <h1 class="text-2xl font-bold">Relatórios</h1>
+                        <div class="flex items-center gap-3">
+                            <button type="button" class="mobile-menu-toggle sm:hidden p-2 rounded-full border border-white/30 bg-primary/90 text-white shadow-md" aria-label="Abrir menu" aria-controls="sidebar">
+                                <span class="material-icons">menu</span>
+                            </button>
+                            <h1 class="text-2xl font-bold">Relatórios</h1>
+                        </div>
                         <div class="relative">
                             <button class="user-menu-button flex items-center gap-3 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                                 <img src="https://placehold.co/40x40/6D28D9/FFFFFF?text=U" alt="Avatar do Usuário" class="user-avatar-img w-10 h-10 rounded-full object-cover" loading="lazy" decoding="async" data-fallback-src="img/placeholders/avatar-placeholder.svg" onerror="if(!this.dataset.fallbackApplied){this.dataset.fallbackApplied='true';this.src=this.dataset.fallbackSrc;}">
@@ -350,7 +369,12 @@
                 <!-- Approve Page -->
                 <div id="approve-page" class="page-content hidden flex-1 flex flex-col min-h-0">
                     <header class="flex justify-between items-center p-6 bg-surface-light dark:bg-surface-dark border-b dark:border-gray-700">
-                        <h1 class="text-2xl font-bold text-text-light dark:text-text-dark">Gerenciar Cadastros</h1>
+                        <div class="flex items-center gap-3">
+                            <button type="button" class="mobile-menu-toggle sm:hidden p-2 rounded-full border border-white/30 bg-primary/90 text-white shadow-md" aria-label="Abrir menu" aria-controls="sidebar">
+                                <span class="material-icons">menu</span>
+                            </button>
+                            <h1 class="text-2xl font-bold text-text-light dark:text-text-dark">Gerenciar Cadastros</h1>
+                        </div>
                         <div class="relative">
                             <button class="user-menu-button flex items-center gap-3 p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                                 <img src="https://placehold.co/40x40/6D28D9/FFFFFF?text=U" alt="Avatar do Usuário" class="user-avatar-img w-10 h-10 rounded-full object-cover" loading="lazy" decoding="async" data-fallback-src="img/placeholders/avatar-placeholder.svg" onerror="if(!this.dataset.fallbackApplied){this.dataset.fallbackApplied='true';this.src=this.dataset.fallbackSrc;}">
@@ -380,7 +404,12 @@
                 <!-- Moves Page -->
                 <div id="moves-page" class="page-content hidden flex-1 flex flex-col min-h-0">
                     <header class="flex justify-between items-center p-6 bg-surface-light dark:bg-surface-dark border-b dark:border-gray-700">
-                        <h1 class="text-2xl font-bold">Movimentações</h1>
+                        <div class="flex items-center gap-3">
+                            <button type="button" class="mobile-menu-toggle sm:hidden p-2 rounded-full border border-white/30 bg-primary/90 text-white shadow-md" aria-label="Abrir menu" aria-controls="sidebar">
+                                <span class="material-icons">menu</span>
+                            </button>
+                            <h1 class="text-2xl font-bold">Movimentações</h1>
+                        </div>
                     </header>
                     <div class="flex-1 p-8 bg-background-light dark:bg-background-dark overflow-y-auto">
                         <div class="bg-surface-light dark:bg-surface-dark rounded-xl shadow-sm p-6">

--- a/javascript.js
+++ b/javascript.js
@@ -47,6 +47,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Elementos gerais da aplicação
   const mainMenu = document.getElementById('main-menu');
+  const sidebar = document.getElementById('sidebar');
+  const sidebarBackdrop = document.getElementById('sidebar-backdrop');
+  const mobileMenuToggles = document.querySelectorAll('.mobile-menu-toggle');
+  const mobileMenuCloseButtons = document.querySelectorAll('.mobile-menu-close');
   const stockMenuItem = document.getElementById('stock-menu-item');
   const pageContents = document.querySelectorAll('.page-content');
   const addProductLink = document.getElementById('add-product-link');
@@ -104,6 +108,78 @@ document.addEventListener('DOMContentLoaded', () => {
   const userAvatarImgs = document.querySelectorAll('.user-avatar-img');
 
   let currentProductId = null;
+  let isMobileSidebarOpen = false;
+
+  const isDesktopViewport = () => window.matchMedia('(min-width: 640px)').matches;
+
+  const setSidebarState = isOpen => {
+    if (!sidebar) return;
+    if (isOpen) {
+      sidebar.setAttribute('data-open', 'true');
+      sidebarBackdrop?.setAttribute('data-visible', 'true');
+      document.body.classList.add('sidebar-locked');
+    } else {
+      sidebar.removeAttribute('data-open');
+      sidebarBackdrop?.removeAttribute('data-visible');
+      document.body.classList.remove('sidebar-locked');
+    }
+    const shouldHideForAccessibility = !isOpen && !isDesktopViewport();
+    sidebar.setAttribute('aria-hidden', shouldHideForAccessibility ? 'true' : 'false');
+    mobileMenuToggles.forEach(button => button.setAttribute('aria-expanded', isOpen ? 'true' : 'false'));
+    isMobileSidebarOpen = isOpen;
+  };
+
+  const openMobileSidebar = () => {
+    if (isDesktopViewport()) return;
+    setSidebarState(true);
+  };
+
+  const closeMobileSidebar = force => {
+    if (!isMobileSidebarOpen && !force) return;
+    setSidebarState(false);
+  };
+
+  mobileMenuToggles.forEach(button => {
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      if (isMobileSidebarOpen) {
+        closeMobileSidebar();
+      } else {
+        openMobileSidebar();
+      }
+    });
+  });
+
+  mobileMenuCloseButtons.forEach(button => {
+    button.addEventListener('click', event => {
+      event.preventDefault();
+      closeMobileSidebar(true);
+    });
+  });
+
+  sidebarBackdrop?.addEventListener('click', () => closeMobileSidebar(true));
+
+  window.addEventListener('keyup', event => {
+    if (event.key === 'Escape') {
+      closeMobileSidebar(true);
+    }
+  });
+
+  window.addEventListener('resize', () => {
+    if (isDesktopViewport()) {
+      closeMobileSidebar(true);
+    }
+  });
+
+  mainMenu?.addEventListener('click', event => {
+    if (!(event.target instanceof HTMLElement)) return;
+    if (isDesktopViewport()) return;
+    if (event.target.closest('a')) {
+      closeMobileSidebar(true);
+    }
+  });
+
+  closeMobileSidebar(true);
 
   const persistSession = session => {
     if (!session) return;
@@ -526,6 +602,7 @@ document.addEventListener('DOMContentLoaded', () => {
     stopAutoRefresh();
     pendingRealtimeRefresh = false;
     pendingRealtimeOptions = {};
+    closeMobileSidebar(true);
     showLoginScreen();
     inputUsuario.value = '';
     inputClave.value = '';


### PR DESCRIPTION
## Summary
- redesign the application shell to support a responsive sidebar with a backdrop and scrollable menu
- add mobile navigation toggles across all pages and ensure the drawer closes on navigation and logout
- lock page scrolling when the drawer is open and fine-tune layout styles for different viewports

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dc12fa2b80832abd4a433723097fa2