### PR TITLE
Remove top border from Estoque container

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
                 <!-- Stock Page -->
                 <div id="stock-page" class="page-content flex-1 flex flex-col hidden min-h-0 bg-background-light dark:bg-background-dark">
                     <div class="flex-1 flex flex-col items-center px-4 py-6 overflow-hidden">
-                        <div id="stock-page-container" class="w-full max-w-[1400px] flex-1 flex flex-col rounded-2xl border border-gray-200/60 dark:border-gray-700/60 shadow-sm bg-surface-light dark:bg-surface-dark overflow-hidden">
+                        <div id="stock-page-container" class="w-full max-w-[1400px] flex-1 flex flex-col rounded-2xl border-b border-gray-200/60 dark:border-gray-700/60 shadow-sm bg-surface-light dark:bg-surface-dark overflow-hidden">
                             <header class="flex items-center justify-between px-6 py-5 border-b border-gray-200/70 dark:border-gray-700/70 bg-surface-light dark:bg-surface-dark">
                                 <div class="flex items-center gap-3">
                                     <button type="button" class="mobile-menu-toggle sm:hidden p-2 rounded-full border border-white/30 bg-primary/90 text-white shadow-md" aria-label="Abrir menu" aria-controls="sidebar">


### PR DESCRIPTION
## Summary
- adjust the Estoque page container styling to keep only the bottom border, removing the top edge as requested

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd7d1c08d8832a811c82720c355ee4