### PR TITLE
Remove borders from stock page layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,8 +317,8 @@
                 <!-- Stock Page -->
                 <div id="stock-page" class="page-content flex-1 flex flex-col hidden min-h-0 bg-background-light dark:bg-background-dark">
                     <div class="flex-1 flex flex-col items-center px-4 py-6 overflow-hidden">
-                        <div id="stock-page-container" class="w-full max-w-[1400px] flex-1 flex flex-col rounded-2xl border-b border-gray-200/60 dark:border-gray-700/60 shadow-sm bg-surface-light dark:bg-surface-dark overflow-hidden">
-                            <header class="flex items-center justify-between px-6 py-5 border-b border-gray-200/70 dark:border-gray-700/70 bg-surface-light dark:bg-surface-dark">
+                        <div id="stock-page-container" class="w-full max-w-[1400px] flex-1 flex flex-col rounded-2xl shadow-sm bg-surface-light dark:bg-surface-dark overflow-hidden">
+                            <header class="flex items-center justify-between px-6 py-5 bg-surface-light dark:bg-surface-dark">
                                 <div class="flex items-center gap-3">
                                     <button type="button" class="mobile-menu-toggle sm:hidden p-2 rounded-full border border-white/30 bg-primary/90 text-white shadow-md" aria-label="Abrir menu" aria-controls="sidebar">
                                         <span class="material-icons">menu</span>
@@ -339,7 +339,7 @@
                                     </div>
                                 </div>
                             </header>
-                            <div class="px-6 py-5 border-b border-gray-200/70 dark:border-gray-700/70 bg-surface-light dark:bg-surface-dark">
+                            <div class="px-6 py-5 bg-surface-light dark:bg-surface-dark">
                                 <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
                                     <div class="relative flex-1 lg:max-w-md">
                                         <span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">search</span>


### PR DESCRIPTION
## Summary
- remove the outer border styling from the stock page container
- drop header and toolbar separators so the estoque tab appears borderless

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd84f1f3c4832a96e2b03e263b9f2c