### PR TITLE
Ajustar layout da aba de estoque para ocupar largura total

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,7 +71,7 @@
 
         #stock-page-container {
             width: 100%;
-            max-width: 1400px;
+            max-width: none;
         }
 
         #stock-page .filter-btn {
@@ -316,8 +316,8 @@
 
                 <!-- Stock Page -->
                 <div id="stock-page" class="page-content flex-1 flex flex-col hidden min-h-0 bg-background-light dark:bg-background-dark">
-                    <div class="flex-1 flex flex-col items-center px-4 py-6 overflow-hidden">
-                        <div id="stock-page-container" class="w-full max-w-[1400px] flex-1 flex flex-col rounded-2xl shadow-sm bg-surface-light dark:bg-surface-dark overflow-hidden">
+                    <div class="flex-1 flex flex-col items-stretch px-0 py-6 overflow-hidden">
+                        <div id="stock-page-container" class="w-full flex-1 flex flex-col rounded-none lg:rounded-none shadow-sm bg-surface-light dark:bg-surface-dark overflow-hidden">
                             <header class="flex items-center justify-between px-6 py-5 bg-surface-light dark:bg-surface-dark">
                                 <div class="flex items-center gap-3">
                                     <button type="button" class="mobile-menu-toggle sm:hidden p-2 rounded-full border border-white/30 bg-primary/90 text-white shadow-md" aria-label="Abrir menu" aria-controls="sidebar">


### PR DESCRIPTION
## Summary
- remover limite de largura da área principal de estoque para aproveitar toda a tela
- ajustar classes utilitárias para eliminar margens laterais na aba de estoque

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd86fff414832a90462d2c8c5bc3c7