### PR TITLE
Allow dashboard tab container to span full width

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,8 @@
             animation: spin 1s linear infinite;
         }
 
-        #stock-page-container {
+        #stock-page-container,
+        #home-page-container {
             width: 100%;
             max-width: none;
         }
@@ -253,7 +254,7 @@
                             </div>
                         </div>
                     </header>
-                    <div class="flex-1 p-8 overflow-y-auto">
+                    <div id="home-page-container" class="flex-1 p-8 overflow-y-auto">
                         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
                             <div id="home-card-total-stock" class="bg-surface-light dark:bg-surface-dark p-6 rounded-xl shadow-sm flex items-start justify-between cursor-pointer hover:shadow-lg transition-shadow">
                                 <div>


### PR DESCRIPTION
## Summary
- allow the dashboard page container to reuse the full-width rule applied to the stock tab
- add an identifier to the dashboard content wrapper so it can opt out of the previous max-width constraint

## Testing
- npm install
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68dd887c53a4832a9167ffd0936a8a87