### PR TITLE
Point default database URLs to new Render host

### DIFF
--- a/lib/db-defaults.js
+++ b/lib/db-defaults.js
@@ -1,0 +1,9 @@
+export const DEFAULT_DATABASE_URL = 'postgresql://acai:ETShntq0lGuqd1z35WNdCBVRQEfEPF9P@dpg-d4aec52li9vc73fgkne0-a/acai';
+
+export const DEFAULT_DATABASE_URL_EXTERNAL =
+  'postgresql://acai:ETShntq0lGuqd1z35WNdCBVRQEfEPF9P@dpg-d4aec52li9vc73fgkne0-a.oregon-postgres.render.com/acai';
+
+export default {
+  DEFAULT_DATABASE_URL,
+  DEFAULT_DATABASE_URL_EXTERNAL,
+};

--- a/scripts/sync-admins.mjs
+++ b/scripts/sync-admins.mjs
@@ -5,6 +5,7 @@ import { Pool } from 'pg';
 
 import { sanitizeText } from '../lib/utils.js';
 import { seedUsersFromFile as importUsersFromSeed } from '../lib/user-seed.js';
+import { DEFAULT_DATABASE_URL, DEFAULT_DATABASE_URL_EXTERNAL } from '../lib/db-defaults.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -16,9 +17,6 @@ const normalizeConnectionString = value => sanitizeText(value) || '';
 const primaryCandidates = [];
 const fallbackCandidates = [];
 const registeredConnections = new Set();
-
-const DEFAULT_DATABASE_URL = 'postgresql://acai:ETShntq0lGuqd1z35WNdCBVRQEfEPF9P@dpg-d4aec52li9vc73fgkne0-a/acai';
-const DEFAULT_DATABASE_URL_EXTERNAL = 'postgresql://acai:ETShntq0lGuqd1z35WNdCBVRQEfEPF9P@dpg-d4aec52li9vc73fgkne0-a.oregon-postgres.render.com/acai';
 
 const registerCandidate = (label, value, type) => {
   const normalized = normalizeConnectionString(value);

--- a/server.js
+++ b/server.js
@@ -17,6 +17,7 @@ import { Pool } from 'pg';
 import { sanitizeText, normalizeUsername, sanitizeCost, BCRYPT_SALT_ROUNDS, parsePositiveInt } from './lib/utils.js';
 import { sanitizeClosurePayload, buildClosureResponse, diffClosures } from './lib/cashier-closures.js';
 import { seedUsersFromFile as importUsersFromSeed } from './lib/user-seed.js';
+import { DEFAULT_DATABASE_URL, DEFAULT_DATABASE_URL_EXTERNAL } from './lib/db-defaults.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = path.dirname(__filename);
@@ -152,9 +153,6 @@ const normalizeConnectionString = value => sanitizeText(value) || '';
 const primaryConnectionCandidates = [];
 const fallbackConnectionCandidates = [];
 const registeredConnectionStrings = new Set();
-
-const DEFAULT_DATABASE_URL = 'postgresql://acai:ETShntq0lGuqd1z35WNdCBVRQEfEPF9P@dpg-d4aec52li9vc73fgkne0-a/acai';
-const DEFAULT_DATABASE_URL_EXTERNAL = 'postgresql://acai:ETShntq0lGuqd1z35WNdCBVRQEfEPF9P@dpg-d4aec52li9vc73fgkne0-a.oregon-postgres.render.com/acai';
 
 const registerConnectionCandidate = (label, value, type) => {
   const normalized = normalizeConnectionString(value);


### PR DESCRIPTION
## Summary
- centralize the Render-provided default connection URLs in a shared helper
- reuse the shared defaults in the server bootstrap and admin sync script to ensure the new database host is used everywhere

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914f31c6e44832a9d77f7801517f72e)